### PR TITLE
fix: マークダウンレンダリングを修正するための特殊文字エスケープ処理を追加

### DIFF
--- a/.changeset/wild-grapes-teach.md
+++ b/.changeset/wild-grapes-teach.md
@@ -1,0 +1,5 @@
+---
+"rulens": patch
+---
+
+Added special character escaping to correct markdown rendering

--- a/docs/lint-rules.md
+++ b/docs/lint-rules.md
@@ -48,40 +48,40 @@ Rules in this category ensure that code is accessible to all users, including th
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`noAccessKey`](https://biomejs.dev/linter/rules/no-access-key) | Enforce that the accessKey attribute is not used on any HTML element. |  |
-| [`noAriaHiddenOnFocusable`](https://biomejs.dev/linter/rules/no-aria-hidden-on-focusable) | Enforce that aria-hidden=“true” is not set on focusable elements. |  |
-| [`noAriaUnsupportedElements`](https://biomejs.dev/linter/rules/no-aria-unsupported-elements) | Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes. |  |
-| [`noAutofocus`](https://biomejs.dev/linter/rules/no-autofocus) | Enforce that autoFocus prop is not used on elements. |  |
-| [`noBlankTarget`](https://biomejs.dev/linter/rules/no-blank-target) | Disallow target="_blank" attribute without rel="noreferrer" |  |
-| [`noDistractingElements`](https://biomejs.dev/linter/rules/no-distracting-elements) | Enforces that no distracting elements are used. |  |
-| [`noHeaderScope`](https://biomejs.dev/linter/rules/no-header-scope) | The scope prop should be used only on <th> elements. |  |
-| [`noInteractiveElementToNoninteractiveRole`](https://biomejs.dev/linter/rules/no-interactive-element-to-noninteractive-role) | Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements. |  |
-| [`noLabelWithoutControl`](https://biomejs.dev/linter/rules/no-label-without-control) | Enforce that a label element or component has a text label and an associated input. |  |
-| [`noNoninteractiveElementToInteractiveRole`](https://biomejs.dev/linter/rules/no-noninteractive-element-to-interactive-role) | Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements. |  |
-| [`noNoninteractiveTabindex`](https://biomejs.dev/linter/rules/no-noninteractive-tabindex) | Enforce that tabIndex is not assigned to non-interactive HTML elements. |  |
+| [`noAccessKey`](https://biomejs.dev/linter/rules/no-access-key) | Enforce that the accessKey attribute is not used on any HTML element\. |  |
+| [`noAriaHiddenOnFocusable`](https://biomejs.dev/linter/rules/no-aria-hidden-on-focusable) | Enforce that aria\-hidden=“true” is not set on focusable elements\. |  |
+| [`noAriaUnsupportedElements`](https://biomejs.dev/linter/rules/no-aria-unsupported-elements) | Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes\. |  |
+| [`noAutofocus`](https://biomejs.dev/linter/rules/no-autofocus) | Enforce that autoFocus prop is not used on elements\. |  |
+| [`noBlankTarget`](https://biomejs.dev/linter/rules/no-blank-target) | Disallow target="\_blank" attribute without rel="noreferrer" |  |
+| [`noDistractingElements`](https://biomejs.dev/linter/rules/no-distracting-elements) | Enforces that no distracting elements are used\. |  |
+| [`noHeaderScope`](https://biomejs.dev/linter/rules/no-header-scope) | The scope prop should be used only on \<th\> elements\. |  |
+| [`noInteractiveElementToNoninteractiveRole`](https://biomejs.dev/linter/rules/no-interactive-element-to-noninteractive-role) | Enforce that non\-interactive ARIA roles are not assigned to interactive HTML elements\. |  |
+| [`noLabelWithoutControl`](https://biomejs.dev/linter/rules/no-label-without-control) | Enforce that a label element or component has a text label and an associated input\. |  |
+| [`noNoninteractiveElementToInteractiveRole`](https://biomejs.dev/linter/rules/no-noninteractive-element-to-interactive-role) | Enforce that interactive ARIA roles are not assigned to non\-interactive HTML elements\. |  |
+| [`noNoninteractiveTabindex`](https://biomejs.dev/linter/rules/no-noninteractive-tabindex) | Enforce that tabIndex is not assigned to non\-interactive HTML elements\. |  |
 | [`noPositiveTabindex`](https://biomejs.dev/linter/rules/no-positive-tabindex) | Prevent the usage of positive integers on tabIndex property |  |
-| [`noRedundantAlt`](https://biomejs.dev/linter/rules/no-redundant-alt) | Enforce img alt prop does not contain the word “image”, “picture”, or “photo”. |  |
-| [`noRedundantRoles`](https://biomejs.dev/linter/rules/no-redundant-roles) | Enforce explicit role property is not the same as implicit/default role property on an element. |  |
-| [`noSvgWithoutTitle`](https://biomejs.dev/linter/rules/no-svg-without-title) | Enforces the usage of the title element for the svg element. |  |
-| [`useAltText`](https://biomejs.dev/linter/rules/use-alt-text) | Enforce that all elements that require alternative text have meaningful information to relay back to the end user. |  |
-| [`useAnchorContent`](https://biomejs.dev/linter/rules/use-anchor-content) | Enforce that anchors have content and that the content is accessible to screen readers. |  |
-| [`useAriaActivedescendantWithTabindex`](https://biomejs.dev/linter/rules/use-aria-activedescendant-with-tabindex) | Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant. |  |
-| [`useAriaPropsForRole`](https://biomejs.dev/linter/rules/use-aria-props-for-role) | Enforce that elements with ARIA roles must have all required ARIA attributes for that role. |  |
+| [`noRedundantAlt`](https://biomejs.dev/linter/rules/no-redundant-alt) | Enforce img alt prop does not contain the word “image”, “picture”, or “photo”\. |  |
+| [`noRedundantRoles`](https://biomejs.dev/linter/rules/no-redundant-roles) | Enforce explicit role property is not the same as implicit/default role property on an element\. |  |
+| [`noSvgWithoutTitle`](https://biomejs.dev/linter/rules/no-svg-without-title) | Enforces the usage of the title element for the svg element\. |  |
+| [`useAltText`](https://biomejs.dev/linter/rules/use-alt-text) | Enforce that all elements that require alternative text have meaningful information to relay back to the end user\. |  |
+| [`useAnchorContent`](https://biomejs.dev/linter/rules/use-anchor-content) | Enforce that anchors have content and that the content is accessible to screen readers\. |  |
+| [`useAriaActivedescendantWithTabindex`](https://biomejs.dev/linter/rules/use-aria-activedescendant-with-tabindex) | Enforce that tabIndex is assigned to non\-interactive HTML elements with aria\-activedescendant\. |  |
+| [`useAriaPropsForRole`](https://biomejs.dev/linter/rules/use-aria-props-for-role) | Enforce that elements with ARIA roles must have all required ARIA attributes for that role\. |  |
 | [`useButtonType`](https://biomejs.dev/linter/rules/use-button-type) | Enforces the usage of the attribute type for the element button |  |
-| [`useFocusableInteractive`](https://biomejs.dev/linter/rules/use-focusable-interactive) | Elements with an interactive role and interaction handlers must be focusable. |  |
-| [`useGenericFontNames`](https://biomejs.dev/linter/rules/use-generic-font-names) | Disallow a missing generic family keyword within font families. |  |
-| [`useHeadingContent`](https://biomejs.dev/linter/rules/use-heading-content) | Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop. |  |
-| [`useHtmlLang`](https://biomejs.dev/linter/rules/use-html-lang) | Enforce that html element has lang attribute. |  |
-| [`useIframeTitle`](https://biomejs.dev/linter/rules/use-iframe-title) | Enforces the usage of the attribute title for the element iframe. |  |
-| [`useKeyWithClickEvents`](https://biomejs.dev/linter/rules/use-key-with-click-events) | Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress. |  |
-| [`useKeyWithMouseEvents`](https://biomejs.dev/linter/rules/use-key-with-mouse-events) | Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur. |  |
-| [`useMediaCaption`](https://biomejs.dev/linter/rules/use-media-caption) | Enforces that audio and video elements must have a track for captions. |  |
-| [`useSemanticElements`](https://biomejs.dev/linter/rules/use-semantic-elements) | It detects the use of role attributes in JSX elements and suggests using semantic elements instead. |  |
-| [`useValidAnchor`](https://biomejs.dev/linter/rules/use-valid-anchor) | Enforce that all anchors are valid, and they are navigable elements. |  |
-| [`useValidAriaProps`](https://biomejs.dev/linter/rules/use-valid-aria-props) | Ensures that ARIA properties aria-* are all valid. |  |
-| [`useValidAriaRole`](https://biomejs.dev/linter/rules/use-valid-aria-role) | Elements with ARIA roles must use a valid, non-abstract ARIA role. |  |
-| [`useValidAriaValues`](https://biomejs.dev/linter/rules/use-valid-aria-values) | Enforce that ARIA state and property values are valid. |  |
-| [`useValidLang`](https://biomejs.dev/linter/rules/use-valid-lang) | Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country. |  |
+| [`useFocusableInteractive`](https://biomejs.dev/linter/rules/use-focusable-interactive) | Elements with an interactive role and interaction handlers must be focusable\. |  |
+| [`useGenericFontNames`](https://biomejs.dev/linter/rules/use-generic-font-names) | Disallow a missing generic family keyword within font families\. |  |
+| [`useHeadingContent`](https://biomejs.dev/linter/rules/use-heading-content) | Enforce that heading elements \(h1, h2, etc\.\) have content and that the content is accessible to screen readers\. Accessible means that it is not hidden using the aria\-hidden prop\. |  |
+| [`useHtmlLang`](https://biomejs.dev/linter/rules/use-html-lang) | Enforce that html element has lang attribute\. |  |
+| [`useIframeTitle`](https://biomejs.dev/linter/rules/use-iframe-title) | Enforces the usage of the attribute title for the element iframe\. |  |
+| [`useKeyWithClickEvents`](https://biomejs.dev/linter/rules/use-key-with-click-events) | Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress\. |  |
+| [`useKeyWithMouseEvents`](https://biomejs.dev/linter/rules/use-key-with-mouse-events) | Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur\. |  |
+| [`useMediaCaption`](https://biomejs.dev/linter/rules/use-media-caption) | Enforces that audio and video elements must have a track for captions\. |  |
+| [`useSemanticElements`](https://biomejs.dev/linter/rules/use-semantic-elements) | It detects the use of role attributes in JSX elements and suggests using semantic elements instead\. |  |
+| [`useValidAnchor`](https://biomejs.dev/linter/rules/use-valid-anchor) | Enforce that all anchors are valid, and they are navigable elements\. |  |
+| [`useValidAriaProps`](https://biomejs.dev/linter/rules/use-valid-aria-props) | Ensures that ARIA properties aria\-\* are all valid\. |  |
+| [`useValidAriaRole`](https://biomejs.dev/linter/rules/use-valid-aria-role) | Elements with ARIA roles must use a valid, non\-abstract ARIA role\. |  |
+| [`useValidAriaValues`](https://biomejs.dev/linter/rules/use-valid-aria-values) | Enforce that ARIA state and property values are valid\. |  |
+| [`useValidLang`](https://biomejs.dev/linter/rules/use-valid-lang) | Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country\. |  |
 
 ---
 
@@ -91,37 +91,37 @@ Rules in this category help maintain code that is easy to understand, modify, an
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`noBannedTypes`](https://biomejs.dev/linter/rules/no-banned-types) | Disallow primitive type aliases and misleading types. |  |
-| [`noEmptyTypeParameters`](https://biomejs.dev/linter/rules/no-empty-type-parameters) | Disallow empty type parameters in type aliases and interfaces. |  |
-| [`noExcessiveCognitiveComplexity`](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity) | Disallow functions that exceed a given Cognitive Complexity score. |  |
-| [`noExcessiveNestedTestSuites`](https://biomejs.dev/linter/rules/no-excessive-nested-test-suites) | This rule enforces a maximum depth to nested describe() in test files. |  |
+| [`noBannedTypes`](https://biomejs.dev/linter/rules/no-banned-types) | Disallow primitive type aliases and misleading types\. |  |
+| [`noEmptyTypeParameters`](https://biomejs.dev/linter/rules/no-empty-type-parameters) | Disallow empty type parameters in type aliases and interfaces\. |  |
+| [`noExcessiveCognitiveComplexity`](https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity) | Disallow functions that exceed a given Cognitive Complexity score\. |  |
+| [`noExcessiveNestedTestSuites`](https://biomejs.dev/linter/rules/no-excessive-nested-test-suites) | This rule enforces a maximum depth to nested describe\(\) in test files\. |  |
 | [`noExtraBooleanCast`](https://biomejs.dev/linter/rules/no-extra-boolean-cast) | Disallow unnecessary boolean casts |  |
-| [`noForEach`](https://biomejs.dev/linter/rules/no-for-each) | Prefer for...of statement instead of Array.forEach. |  |
+| [`noForEach`](https://biomejs.dev/linter/rules/no-for-each) | Prefer for\.\.\.of statement instead of Array\.forEach\. |  |
 | [`noMultipleSpacesInRegularExpressionLiterals`](https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals) | Disallow unclear usage of consecutive space characters in regular expression literals |  |
-| [`noStaticOnlyClass`](https://biomejs.dev/linter/rules/no-static-only-class) | This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace. |  |
-| [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static) | Disallow this and super in static contexts. |  |
-| [`noUselessCatch`](https://biomejs.dev/linter/rules/no-useless-catch) | Disallow unnecessary catch clauses. |  |
-| [`noUselessConstructor`](https://biomejs.dev/linter/rules/no-useless-constructor) | Disallow unnecessary constructors. |  |
-| [`noUselessEmptyExport`](https://biomejs.dev/linter/rules/no-useless-empty-export) | Disallow empty exports that don’t change anything in a module file. |  |
+| [`noStaticOnlyClass`](https://biomejs.dev/linter/rules/no-static-only-class) | This rule reports when a class has no non\-static members, such as for a class used exclusively as a static namespace\. |  |
+| [`noThisInStatic`](https://biomejs.dev/linter/rules/no-this-in-static) | Disallow this and super in static contexts\. |  |
+| [`noUselessCatch`](https://biomejs.dev/linter/rules/no-useless-catch) | Disallow unnecessary catch clauses\. |  |
+| [`noUselessConstructor`](https://biomejs.dev/linter/rules/no-useless-constructor) | Disallow unnecessary constructors\. |  |
+| [`noUselessEmptyExport`](https://biomejs.dev/linter/rules/no-useless-empty-export) | Disallow empty exports that don’t change anything in a module file\. |  |
 | [`noUselessFragments`](https://biomejs.dev/linter/rules/no-useless-fragments) | Disallow unnecessary fragments |  |
-| [`noUselessLabel`](https://biomejs.dev/linter/rules/no-useless-label) | Disallow unnecessary labels. |  |
-| [`noUselessLoneBlockStatements`](https://biomejs.dev/linter/rules/no-useless-lone-block-statements) | Disallow unnecessary nested block statements. |  |
-| [`noUselessRename`](https://biomejs.dev/linter/rules/no-useless-rename) | Disallow renaming import, export, and destructured assignments to the same name. |  |
-| [`noUselessStringConcat`](https://biomejs.dev/linter/rules/no-useless-string-concat) | Disallow unnecessary concatenation of string or template literals. |  |
-| [`noUselessSwitchCase`](https://biomejs.dev/linter/rules/no-useless-switch-case) | Disallow useless case in switch statements. |  |
-| [`noUselessTernary`](https://biomejs.dev/linter/rules/no-useless-ternary) | Disallow ternary operators when simpler alternatives exist. |  |
-| [`noUselessThisAlias`](https://biomejs.dev/linter/rules/no-useless-this-alias) | Disallow useless this aliasing. |  |
-| [`noUselessTypeConstraint`](https://biomejs.dev/linter/rules/no-useless-type-constraint) | Disallow using any or unknown as type constraint. |  |
-| [`noUselessUndefinedInitialization`](https://biomejs.dev/linter/rules/no-useless-undefined-initialization) | Disallow initializing variables to undefined. |  |
-| [`noVoid`](https://biomejs.dev/linter/rules/no-void) | Disallow the use of void operators, which is not a familiar operator. |  |
-| [`noWith`](https://biomejs.dev/linter/rules/no-with) | Disallow with statements in non-strict contexts. |  |
-| [`useArrowFunction`](https://biomejs.dev/linter/rules/use-arrow-function) | Use arrow functions over function expressions. |  |
-| [`useDateNow`](https://biomejs.dev/linter/rules/use-date-now) | Use Date.now() to get the number of milliseconds since the Unix Epoch. |  |
-| [`useFlatMap`](https://biomejs.dev/linter/rules/use-flat-map) | Promotes the use of .flatMap() when map().flat() are used together. |  |
-| [`useOptionalChain`](https://biomejs.dev/linter/rules/use-optional-chain) | Enforce using concise optional chain instead of chained logical expressions. |  |
-| [`useRegexLiterals`](https://biomejs.dev/linter/rules/use-regex-literals) | Enforce the use of the regular expression literals instead of the RegExp constructor if possible. |  |
+| [`noUselessLabel`](https://biomejs.dev/linter/rules/no-useless-label) | Disallow unnecessary labels\. |  |
+| [`noUselessLoneBlockStatements`](https://biomejs.dev/linter/rules/no-useless-lone-block-statements) | Disallow unnecessary nested block statements\. |  |
+| [`noUselessRename`](https://biomejs.dev/linter/rules/no-useless-rename) | Disallow renaming import, export, and destructured assignments to the same name\. |  |
+| [`noUselessStringConcat`](https://biomejs.dev/linter/rules/no-useless-string-concat) | Disallow unnecessary concatenation of string or template literals\. |  |
+| [`noUselessSwitchCase`](https://biomejs.dev/linter/rules/no-useless-switch-case) | Disallow useless case in switch statements\. |  |
+| [`noUselessTernary`](https://biomejs.dev/linter/rules/no-useless-ternary) | Disallow ternary operators when simpler alternatives exist\. |  |
+| [`noUselessThisAlias`](https://biomejs.dev/linter/rules/no-useless-this-alias) | Disallow useless this aliasing\. |  |
+| [`noUselessTypeConstraint`](https://biomejs.dev/linter/rules/no-useless-type-constraint) | Disallow using any or unknown as type constraint\. |  |
+| [`noUselessUndefinedInitialization`](https://biomejs.dev/linter/rules/no-useless-undefined-initialization) | Disallow initializing variables to undefined\. |  |
+| [`noVoid`](https://biomejs.dev/linter/rules/no-void) | Disallow the use of void operators, which is not a familiar operator\. |  |
+| [`noWith`](https://biomejs.dev/linter/rules/no-with) | Disallow with statements in non\-strict contexts\. |  |
+| [`useArrowFunction`](https://biomejs.dev/linter/rules/use-arrow-function) | Use arrow functions over function expressions\. |  |
+| [`useDateNow`](https://biomejs.dev/linter/rules/use-date-now) | Use Date\.now\(\) to get the number of milliseconds since the Unix Epoch\. |  |
+| [`useFlatMap`](https://biomejs.dev/linter/rules/use-flat-map) | Promotes the use of \.flatMap\(\) when map\(\)\.flat\(\) are used together\. |  |
+| [`useOptionalChain`](https://biomejs.dev/linter/rules/use-optional-chain) | Enforce using concise optional chain instead of chained logical expressions\. |  |
+| [`useRegexLiterals`](https://biomejs.dev/linter/rules/use-regex-literals) | Enforce the use of the regular expression literals instead of the RegExp constructor if possible\. |  |
 | [`useSimpleNumberKeys`](https://biomejs.dev/linter/rules/use-simple-number-keys) | Disallow number literal object member names which are not base10 or uses underscore as separator |  |
-| [`useSimplifiedLogicExpression`](https://biomejs.dev/linter/rules/use-simplified-logic-expression) | Discard redundant terms from logical expressions. |  |
+| [`useSimplifiedLogicExpression`](https://biomejs.dev/linter/rules/use-simplified-logic-expression) | Discard redundant terms from logical expressions\. |  |
 
 ---
 
@@ -131,58 +131,58 @@ Rules in this category identify code that is likely to be incorrect or lead to b
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`noChildrenProp`](https://biomejs.dev/linter/rules/no-children-prop) | Prevent passing of children as props. |  |
+| [`noChildrenProp`](https://biomejs.dev/linter/rules/no-children-prop) | Prevent passing of children as props\. |  |
 | [`noConstantCondition`](https://biomejs.dev/linter/rules/no-constant-condition) | Disallow constant expressions in conditions |  |
-| [`noConstantMathMinMaxClamp`](https://biomejs.dev/linter/rules/no-constant-math-min-max-clamp) | Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant. |  |
-| [`noConstAssign`](https://biomejs.dev/linter/rules/no-const-assign) | Prevents from having const variables being re-assigned. |  |
-| [`noConstructorReturn`](https://biomejs.dev/linter/rules/no-constructor-return) | Disallow returning a value from a constructor. |  |
-| [`noEmptyCharacterClassInRegex`](https://biomejs.dev/linter/rules/no-empty-character-class-in-regex) | Disallow empty character classes in regular expression literals. |  |
-| [`noEmptyPattern`](https://biomejs.dev/linter/rules/no-empty-pattern) | Disallows empty destructuring patterns. |  |
-| [`noFlatMapIdentity`](https://biomejs.dev/linter/rules/no-flat-map-identity) | Disallow to use unnecessary callback on flatMap. |  |
+| [`noConstantMathMinMaxClamp`](https://biomejs.dev/linter/rules/no-constant-math-min-max-clamp) | Disallow the use of Math\.min and Math\.max to clamp a value where the result itself is constant\. |  |
+| [`noConstAssign`](https://biomejs.dev/linter/rules/no-const-assign) | Prevents from having const variables being re\-assigned\. |  |
+| [`noConstructorReturn`](https://biomejs.dev/linter/rules/no-constructor-return) | Disallow returning a value from a constructor\. |  |
+| [`noEmptyCharacterClassInRegex`](https://biomejs.dev/linter/rules/no-empty-character-class-in-regex) | Disallow empty character classes in regular expression literals\. |  |
+| [`noEmptyPattern`](https://biomejs.dev/linter/rules/no-empty-pattern) | Disallows empty destructuring patterns\. |  |
+| [`noFlatMapIdentity`](https://biomejs.dev/linter/rules/no-flat-map-identity) | Disallow to use unnecessary callback on flatMap\. |  |
 | [`noGlobalObjectCalls`](https://biomejs.dev/linter/rules/no-global-object-calls) | Disallow calling global object properties as functions |  |
-| [`noInnerDeclarations`](https://biomejs.dev/linter/rules/no-inner-declarations) | Disallow function and var declarations that are accessible outside their block. |  |
-| [`noInvalidBuiltinInstantiation`](https://biomejs.dev/linter/rules/no-invalid-builtin-instantiation) | Ensure that builtins are correctly instantiated. |  |
-| [`noInvalidConstructorSuper`](https://biomejs.dev/linter/rules/no-invalid-constructor-super) | Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors. |  |
-| [`noInvalidDirectionInLinearGradient`](https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient) | Disallow non-standard direction values for linear gradient functions. |  |
-| [`noInvalidGridAreas`](https://biomejs.dev/linter/rules/no-invalid-grid-areas) | Disallows invalid named grid areas in CSS Grid Layouts. |  |
-| [`noInvalidNewBuiltin`](https://biomejs.dev/linter/rules/no-invalid-new-builtin) | Disallow new operators with global non-constructor functions. |  |
-| [`noInvalidPositionAtImportRule`](https://biomejs.dev/linter/rules/no-invalid-position-at-import-rule) | Disallow the use of @import at-rules in invalid positions. |  |
+| [`noInnerDeclarations`](https://biomejs.dev/linter/rules/no-inner-declarations) | Disallow function and var declarations that are accessible outside their block\. |  |
+| [`noInvalidBuiltinInstantiation`](https://biomejs.dev/linter/rules/no-invalid-builtin-instantiation) | Ensure that builtins are correctly instantiated\. |  |
+| [`noInvalidConstructorSuper`](https://biomejs.dev/linter/rules/no-invalid-constructor-super) | Prevents the incorrect use of super\(\) inside classes\. It also checks whether a call super\(\) is missing from classes that extends other constructors\. |  |
+| [`noInvalidDirectionInLinearGradient`](https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient) | Disallow non\-standard direction values for linear gradient functions\. |  |
+| [`noInvalidGridAreas`](https://biomejs.dev/linter/rules/no-invalid-grid-areas) | Disallows invalid named grid areas in CSS Grid Layouts\. |  |
+| [`noInvalidNewBuiltin`](https://biomejs.dev/linter/rules/no-invalid-new-builtin) | Disallow new operators with global non\-constructor functions\. |  |
+| [`noInvalidPositionAtImportRule`](https://biomejs.dev/linter/rules/no-invalid-position-at-import-rule) | Disallow the use of @import at\-rules in invalid positions\. |  |
 | [`noInvalidUseBeforeDeclaration`](https://biomejs.dev/linter/rules/no-invalid-use-before-declaration) | Disallow the use of variables and function parameters before their declaration |  |
-| [`noNewSymbol`](https://biomejs.dev/linter/rules/no-new-symbol) | Disallow new operators with the Symbol object. |  |
-| [`noNonoctalDecimalEscape`](https://biomejs.dev/linter/rules/no-nonoctal-decimal-escape) | Disallow \8 and \9 escape sequences in string literals. |  |
+| [`noNewSymbol`](https://biomejs.dev/linter/rules/no-new-symbol) | Disallow new operators with the Symbol object\. |  |
+| [`noNonoctalDecimalEscape`](https://biomejs.dev/linter/rules/no-nonoctal-decimal-escape) | Disallow \8 and \9 escape sequences in string literals\. |  |
 | [`noPrecisionLoss`](https://biomejs.dev/linter/rules/no-precision-loss) | Disallow literal numbers that lose precision |  |
-| [`noRenderReturnValue`](https://biomejs.dev/linter/rules/no-render-return-value) | Prevent the usage of the return value of React.render. |  |
-| [`noSelfAssign`](https://biomejs.dev/linter/rules/no-self-assign) | Disallow assignments where both sides are exactly the same. |  |
+| [`noRenderReturnValue`](https://biomejs.dev/linter/rules/no-render-return-value) | Prevent the usage of the return value of React\.render\. |  |
+| [`noSelfAssign`](https://biomejs.dev/linter/rules/no-self-assign) | Disallow assignments where both sides are exactly the same\. |  |
 | [`noSetterReturn`](https://biomejs.dev/linter/rules/no-setter-return) | Disallow returning a value from a setter |  |
-| [`noStringCaseMismatch`](https://biomejs.dev/linter/rules/no-string-case-mismatch) | Disallow comparison of expressions modifying the string case with non-compliant value. |  |
-| [`noSwitchDeclarations`](https://biomejs.dev/linter/rules/no-switch-declarations) | Disallow lexical declarations in switch clauses. |  |
-| [`noUndeclaredDependencies`](https://biomejs.dev/linter/rules/no-undeclared-dependencies) | Disallow the use of dependencies that aren’t specified in the package.json. |  |
-| [`noUndeclaredVariables`](https://biomejs.dev/linter/rules/no-undeclared-variables) | Prevents the usage of variables that haven’t been declared inside the document. |  |
-| [`noUnknownFunction`](https://biomejs.dev/linter/rules/no-unknown-function) | Disallow unknown CSS value functions. |  |
-| [`noUnknownMediaFeatureName`](https://biomejs.dev/linter/rules/no-unknown-media-feature-name) | Disallow unknown media feature names. |  |
-| [`noUnknownProperty`](https://biomejs.dev/linter/rules/no-unknown-property) | Disallow unknown properties. |  |
-| [`noUnknownUnit`](https://biomejs.dev/linter/rules/no-unknown-unit) | Disallow unknown CSS units. |  |
-| [`noUnmatchableAnbSelector`](https://biomejs.dev/linter/rules/no-unmatchable-anb-selector) | Disallow unmatchable An+B selectors. |  |
-| [`noUnnecessaryContinue`](https://biomejs.dev/linter/rules/no-unnecessary-continue) | Avoid using unnecessary continue. |  |
+| [`noStringCaseMismatch`](https://biomejs.dev/linter/rules/no-string-case-mismatch) | Disallow comparison of expressions modifying the string case with non\-compliant value\. |  |
+| [`noSwitchDeclarations`](https://biomejs.dev/linter/rules/no-switch-declarations) | Disallow lexical declarations in switch clauses\. |  |
+| [`noUndeclaredDependencies`](https://biomejs.dev/linter/rules/no-undeclared-dependencies) | Disallow the use of dependencies that aren’t specified in the package\.json\. |  |
+| [`noUndeclaredVariables`](https://biomejs.dev/linter/rules/no-undeclared-variables) | Prevents the usage of variables that haven’t been declared inside the document\. |  |
+| [`noUnknownFunction`](https://biomejs.dev/linter/rules/no-unknown-function) | Disallow unknown CSS value functions\. |  |
+| [`noUnknownMediaFeatureName`](https://biomejs.dev/linter/rules/no-unknown-media-feature-name) | Disallow unknown media feature names\. |  |
+| [`noUnknownProperty`](https://biomejs.dev/linter/rules/no-unknown-property) | Disallow unknown properties\. |  |
+| [`noUnknownUnit`](https://biomejs.dev/linter/rules/no-unknown-unit) | Disallow unknown CSS units\. |  |
+| [`noUnmatchableAnbSelector`](https://biomejs.dev/linter/rules/no-unmatchable-anb-selector) | Disallow unmatchable An\+B selectors\. |  |
+| [`noUnnecessaryContinue`](https://biomejs.dev/linter/rules/no-unnecessary-continue) | Avoid using unnecessary continue\. |  |
 | [`noUnreachable`](https://biomejs.dev/linter/rules/no-unreachable) | Disallow unreachable code |  |
-| [`noUnreachableSuper`](https://biomejs.dev/linter/rules/no-unreachable-super) | Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass |  |
-| [`noUnsafeFinally`](https://biomejs.dev/linter/rules/no-unsafe-finally) | Disallow control flow statements in finally blocks. |  |
-| [`noUnsafeOptionalChaining`](https://biomejs.dev/linter/rules/no-unsafe-optional-chaining) | Disallow the use of optional chaining in contexts where the undefined value is not allowed. |  |
-| [`noUnusedFunctionParameters`](https://biomejs.dev/linter/rules/no-unused-function-parameters) | Disallow unused function parameters. |  |
-| [`noUnusedImports`](https://biomejs.dev/linter/rules/no-unused-imports) | Disallow unused imports. |  |
-| [`noUnusedLabels`](https://biomejs.dev/linter/rules/no-unused-labels) | Disallow unused labels. |  |
+| [`noUnreachableSuper`](https://biomejs.dev/linter/rules/no-unreachable-super) | Ensures the super\(\) constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass |  |
+| [`noUnsafeFinally`](https://biomejs.dev/linter/rules/no-unsafe-finally) | Disallow control flow statements in finally blocks\. |  |
+| [`noUnsafeOptionalChaining`](https://biomejs.dev/linter/rules/no-unsafe-optional-chaining) | Disallow the use of optional chaining in contexts where the undefined value is not allowed\. |  |
+| [`noUnusedFunctionParameters`](https://biomejs.dev/linter/rules/no-unused-function-parameters) | Disallow unused function parameters\. |  |
+| [`noUnusedImports`](https://biomejs.dev/linter/rules/no-unused-imports) | Disallow unused imports\. |  |
+| [`noUnusedLabels`](https://biomejs.dev/linter/rules/no-unused-labels) | Disallow unused labels\. |  |
 | [`noUnusedPrivateClassMembers`](https://biomejs.dev/linter/rules/no-unused-private-class-members) | Disallow unused private class members |  |
-| [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables) | Disallow unused variables. |  |
-| [`noVoidElementsWithChildren`](https://biomejs.dev/linter/rules/no-void-elements-with-children) | This rules prevents void elements (AKA self-closing elements) from having children. |  |
+| [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables) | Disallow unused variables\. |  |
+| [`noVoidElementsWithChildren`](https://biomejs.dev/linter/rules/no-void-elements-with-children) | This rules prevents void elements \(AKA self\-closing elements\) from having children\. |  |
 | [`noVoidTypeReturn`](https://biomejs.dev/linter/rules/no-void-type-return) | Disallow returning a value from a function with the return type ‘void’ |  |
-| [`useArrayLiterals`](https://biomejs.dev/linter/rules/use-array-literals) | Disallow Array constructors. |  |
-| [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) | Enforce all dependencies are correctly specified in a React hook. |  |
-| [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level) | Enforce that all React hooks are being called from the Top Level component functions. |  |
-| [`useImportExtensions`](https://biomejs.dev/linter/rules/use-import-extensions) | Enforce file extensions for relative imports. |  |
-| [`useIsNan`](https://biomejs.dev/linter/rules/use-is-nan) | Require calls to isNaN() when checking for NaN. |  |
-| [`useJsxKeyInIterable`](https://biomejs.dev/linter/rules/use-jsx-key-in-iterable) | Disallow missing key props in iterators/collection literals. |  |
-| [`useValidForDirection`](https://biomejs.dev/linter/rules/use-valid-for-direction) | Enforce “for” loop update clause moving the counter in the right direction. |  |
-| [`useYield`](https://biomejs.dev/linter/rules/use-yield) | Require generator functions to contain yield. |  |
+| [`useArrayLiterals`](https://biomejs.dev/linter/rules/use-array-literals) | Disallow Array constructors\. |  |
+| [`useExhaustiveDependencies`](https://biomejs.dev/linter/rules/use-exhaustive-dependencies) | Enforce all dependencies are correctly specified in a React hook\. |  |
+| [`useHookAtTopLevel`](https://biomejs.dev/linter/rules/use-hook-at-top-level) | Enforce that all React hooks are being called from the Top Level component functions\. |  |
+| [`useImportExtensions`](https://biomejs.dev/linter/rules/use-import-extensions) | Enforce file extensions for relative imports\. |  |
+| [`useIsNan`](https://biomejs.dev/linter/rules/use-is-nan) | Require calls to isNaN\(\) when checking for NaN\. |  |
+| [`useJsxKeyInIterable`](https://biomejs.dev/linter/rules/use-jsx-key-in-iterable) | Disallow missing key props in iterators/collection literals\. |  |
+| [`useValidForDirection`](https://biomejs.dev/linter/rules/use-valid-for-direction) | Enforce “for” loop update clause moving the counter in the right direction\. |  |
+| [`useYield`](https://biomejs.dev/linter/rules/use-yield) | Require generator functions to contain yield\. |  |
 
 ---
 
@@ -192,7 +192,7 @@ Newer rules that are still being refined based on community feedback.
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`useExplicitType`](https://biomejs.dev/linter/rules/use-explicit-type) | Require explicit return types on functions and class methods. |  |
+| [`useExplicitType`](https://biomejs.dev/linter/rules/use-explicit-type) | Require explicit return types on functions and class methods\. |  |
 
 ---
 
@@ -202,11 +202,11 @@ Rules in this category help improve application and runtime performance.
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`noAccumulatingSpread`](https://biomejs.dev/linter/rules/no-accumulating-spread) | Disallow the use of spread (...) syntax on accumulators. |  |
-| [`noBarrelFile`](https://biomejs.dev/linter/rules/no-barrel-file) | Disallow the use of barrel file. |  |
-| [`noDelete`](https://biomejs.dev/linter/rules/no-delete) | Disallow the use of the delete operator. |  |
-| [`noReExportAll`](https://biomejs.dev/linter/rules/no-re-export-all) | Avoid re-export all. |  |
-| [`useTopLevelRegex`](https://biomejs.dev/linter/rules/use-top-level-regex) | Require regex literals to be declared at the top level. |  |
+| [`noAccumulatingSpread`](https://biomejs.dev/linter/rules/no-accumulating-spread) | Disallow the use of spread \(\.\.\.\) syntax on accumulators\. |  |
+| [`noBarrelFile`](https://biomejs.dev/linter/rules/no-barrel-file) | Disallow the use of barrel file\. |  |
+| [`noDelete`](https://biomejs.dev/linter/rules/no-delete) | Disallow the use of the delete operator\. |  |
+| [`noReExportAll`](https://biomejs.dev/linter/rules/no-re-export-all) | Avoid re\-export all\. |  |
+| [`useTopLevelRegex`](https://biomejs.dev/linter/rules/use-top-level-regex) | Require regex literals to be declared at the top level\. |  |
 
 ---
 
@@ -217,8 +217,8 @@ Rules in this category identify security vulnerabilities that could be exploited
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
 | [`noDangerouslySetInnerHtml`](https://biomejs.dev/linter/rules/no-dangerously-set-inner-html/) | Prevent the usage of dangerous JSX props |  |
-| [`noDangerouslySetInnerHtmlWithChildren`](https://biomejs.dev/linter/rules/no-dangerously-set-inner-html-with-children) | Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop. |  |
-| [`noGlobalEval`](https://biomejs.dev/linter/rules/no-global-eval) | Disallow the use of global eval(). |  |
+| [`noDangerouslySetInnerHtmlWithChildren`](https://biomejs.dev/linter/rules/no-dangerously-set-inner-html-with-children) | Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop\. |  |
+| [`noGlobalEval`](https://biomejs.dev/linter/rules/no-global-eval) | Disallow the use of global eval\(\)\. |  |
 
 ---
 
@@ -228,54 +228,54 @@ Rules in this category enforce consistent code style and patterns.
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`noArguments`](https://biomejs.dev/linter/rules/no-arguments) | Disallow the use of arguments. |  |
-| [`noCommaOperator`](https://biomejs.dev/linter/rules/no-comma-operator) | Disallow comma operator. |  |
-| [`noDefaultExport`](https://biomejs.dev/linter/rules/no-default-export) | Disallow default exports. |  |
-| [`noDoneCallback`](https://biomejs.dev/linter/rules/no-done-callback) | Disallow using a callback in asynchronous tests and hooks. |  |
-| [`noInferrableTypes`](https://biomejs.dev/linter/rules/no-inferrable-types) | Disallow type annotations for variables, parameters, and class properties initialized with a literal expression. |  |
-| [`noNamespace`](https://biomejs.dev/linter/rules/no-namespace) | Disallow the use of TypeScript’s namespaces. |  |
-| [`noNamespaceImport`](https://biomejs.dev/linter/rules/no-namespace-import) | Disallow the use of namespace imports. |  |
-| [`noNegationElse`](https://biomejs.dev/linter/rules/no-negation-else) | Disallow negation in the condition of an if statement if it has an else clause. |  |
-| [`noNonNullAssertion`](https://biomejs.dev/linter/rules/no-non-null-assertion) | Disallow non-null assertions using the ! postfix operator. |  |
-| [`noParameterAssign`](https://biomejs.dev/linter/rules/no-parameter-assign) | Disallow reassigning function parameters. |  |
-| [`noParameterProperties`](https://biomejs.dev/linter/rules/no-parameter-properties) | Disallow the use of parameter properties in class constructors. |  |
-| [`noRestrictedGlobals`](https://biomejs.dev/linter/rules/no-restricted-globals) | This rule allows you to specify global variable names that you don’t want to use in your application. |  |
-| [`noShoutyConstants`](https://biomejs.dev/linter/rules/no-shouty-constants) | Disallow the use of constants which its value is the upper-case version of its name. |  |
-| [`noUnusedTemplateLiteral`](https://biomejs.dev/linter/rules/no-unused-template-literal) | Disallow template literals if interpolation and special-character handling are not needed |  |
-| [`noUselessElse`](https://biomejs.dev/linter/rules/no-useless-else) | Disallow else block when the if block breaks early. |  |
+| [`noArguments`](https://biomejs.dev/linter/rules/no-arguments) | Disallow the use of arguments\. |  |
+| [`noCommaOperator`](https://biomejs.dev/linter/rules/no-comma-operator) | Disallow comma operator\. |  |
+| [`noDefaultExport`](https://biomejs.dev/linter/rules/no-default-export) | Disallow default exports\. |  |
+| [`noDoneCallback`](https://biomejs.dev/linter/rules/no-done-callback) | Disallow using a callback in asynchronous tests and hooks\. |  |
+| [`noInferrableTypes`](https://biomejs.dev/linter/rules/no-inferrable-types) | Disallow type annotations for variables, parameters, and class properties initialized with a literal expression\. |  |
+| [`noNamespace`](https://biomejs.dev/linter/rules/no-namespace) | Disallow the use of TypeScript’s namespaces\. |  |
+| [`noNamespaceImport`](https://biomejs.dev/linter/rules/no-namespace-import) | Disallow the use of namespace imports\. |  |
+| [`noNegationElse`](https://biomejs.dev/linter/rules/no-negation-else) | Disallow negation in the condition of an if statement if it has an else clause\. |  |
+| [`noNonNullAssertion`](https://biomejs.dev/linter/rules/no-non-null-assertion) | Disallow non\-null assertions using the \! postfix operator\. |  |
+| [`noParameterAssign`](https://biomejs.dev/linter/rules/no-parameter-assign) | Disallow reassigning function parameters\. |  |
+| [`noParameterProperties`](https://biomejs.dev/linter/rules/no-parameter-properties) | Disallow the use of parameter properties in class constructors\. |  |
+| [`noRestrictedGlobals`](https://biomejs.dev/linter/rules/no-restricted-globals) | This rule allows you to specify global variable names that you don’t want to use in your application\. |  |
+| [`noShoutyConstants`](https://biomejs.dev/linter/rules/no-shouty-constants) | Disallow the use of constants which its value is the upper\-case version of its name\. |  |
+| [`noUnusedTemplateLiteral`](https://biomejs.dev/linter/rules/no-unused-template-literal) | Disallow template literals if interpolation and special\-character handling are not needed |  |
+| [`noUselessElse`](https://biomejs.dev/linter/rules/no-useless-else) | Disallow else block when the if block breaks early\. |  |
 | [`noVar`](https://biomejs.dev/linter/rules/no-var) | Disallow the use of var |  |
-| [`noYodaExpression`](https://biomejs.dev/linter/rules/no-yoda-expression) | Disallow the use of yoda expressions. |  |
-| [`useAsConstAssertion`](https://biomejs.dev/linter/rules/use-as-const-assertion) | Enforce the use of as const over literal type and type annotation. |  |
-| [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements) | Requires following curly brace conventions. |  |
-| [`useCollapsedElseIf`](https://biomejs.dev/linter/rules/use-collapsed-else-if) | Enforce using else if instead of nested if in else clauses. |  |
-| [`useConsistentArrayType`](https://biomejs.dev/linter/rules/use-consistent-array-type) | Require consistently using either T[] or Array<T> |  |
-| [`useConsistentBuiltinInstantiation`](https://biomejs.dev/linter/rules/use-consistent-builtin-instantiation) | Enforce the use of new for all builtins, except String, Number and Boolean. |  |
-| [`useConst`](https://biomejs.dev/linter/rules/use-const) | Require const declarations for variables that are only assigned once. |  |
-| [`useDefaultParameterLast`](https://biomejs.dev/linter/rules/use-default-parameter-last) | Enforce default function parameters and optional function parameters to be last. |  |
-| [`useDefaultSwitchClause`](https://biomejs.dev/linter/rules/use-default-switch-clause) | Require the default clause in switch statements. |  |
-| [`useEnumInitializers`](https://biomejs.dev/linter/rules/use-enum-initializers) | Require that each enum member value be explicitly initialized. |  |
-| [`useExplicitLengthCheck`](https://biomejs.dev/linter/rules/use-explicit-length-check) | Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value. |  |
-| [`useExponentiationOperator`](https://biomejs.dev/linter/rules/use-exponentiation-operator) | Disallow the use of Math.pow in favor of the ** operator. |  |
-| [`useExportType`](https://biomejs.dev/linter/rules/use-export-type) | Promotes the use of export type for types. |  |
-| [`useFilenamingConvention`](https://biomejs.dev/linter/rules/use-filenaming-convention) | Enforce naming conventions for JavaScript and TypeScript filenames. |  |
-| [`useForOf`](https://biomejs.dev/linter/rules/use-for-of) | This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array. |  |
-| [`useFragmentSyntax`](https://biomejs.dev/linter/rules/use-fragment-syntax) | This rule enforces the use of <>...</> over <Fragment>...</Fragment>. |  |
-| [`useImportType`](https://biomejs.dev/linter/rules/use-import-type) | Promotes the use of import type for types. |  |
-| [`useLiteralEnumMembers`](https://biomejs.dev/linter/rules/use-literal-enum-members) | Require all enum members to be literal values. |  |
-| [`useNodeAssertStrict`](https://biomejs.dev/linter/rules/use-node-assert-strict) | Promotes the usage of node:assert/strict over node:assert. |  |
-| [`useNodejsImportProtocol`](https://biomejs.dev/linter/rules/use-nodejs-import-protocol) | Enforces using the node: protocol for Node.js builtin modules. |  |
-| [`useNumberNamespace`](https://biomejs.dev/linter/rules/use-number-namespace) | Use the Number properties instead of global ones. |  |
-| [`useNumericLiterals`](https://biomejs.dev/linter/rules/use-numeric-literals) | Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals |  |
+| [`noYodaExpression`](https://biomejs.dev/linter/rules/no-yoda-expression) | Disallow the use of yoda expressions\. |  |
+| [`useAsConstAssertion`](https://biomejs.dev/linter/rules/use-as-const-assertion) | Enforce the use of as const over literal type and type annotation\. |  |
+| [`useBlockStatements`](https://biomejs.dev/linter/rules/use-block-statements) | Requires following curly brace conventions\. |  |
+| [`useCollapsedElseIf`](https://biomejs.dev/linter/rules/use-collapsed-else-if) | Enforce using else if instead of nested if in else clauses\. |  |
+| [`useConsistentArrayType`](https://biomejs.dev/linter/rules/use-consistent-array-type) | Require consistently using either T\[\] or Array\<T\> |  |
+| [`useConsistentBuiltinInstantiation`](https://biomejs.dev/linter/rules/use-consistent-builtin-instantiation) | Enforce the use of new for all builtins, except String, Number and Boolean\. |  |
+| [`useConst`](https://biomejs.dev/linter/rules/use-const) | Require const declarations for variables that are only assigned once\. |  |
+| [`useDefaultParameterLast`](https://biomejs.dev/linter/rules/use-default-parameter-last) | Enforce default function parameters and optional function parameters to be last\. |  |
+| [`useDefaultSwitchClause`](https://biomejs.dev/linter/rules/use-default-switch-clause) | Require the default clause in switch statements\. |  |
+| [`useEnumInitializers`](https://biomejs.dev/linter/rules/use-enum-initializers) | Require that each enum member value be explicitly initialized\. |  |
+| [`useExplicitLengthCheck`](https://biomejs.dev/linter/rules/use-explicit-length-check) | Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value\. |  |
+| [`useExponentiationOperator`](https://biomejs.dev/linter/rules/use-exponentiation-operator) | Disallow the use of Math\.pow in favor of the \*\* operator\. |  |
+| [`useExportType`](https://biomejs.dev/linter/rules/use-export-type) | Promotes the use of export type for types\. |  |
+| [`useFilenamingConvention`](https://biomejs.dev/linter/rules/use-filenaming-convention) | Enforce naming conventions for JavaScript and TypeScript filenames\. |  |
+| [`useForOf`](https://biomejs.dev/linter/rules/use-for-of) | This rule recommends a for\-of loop when in a for loop, the index used to extract an item from the iterated array\. |  |
+| [`useFragmentSyntax`](https://biomejs.dev/linter/rules/use-fragment-syntax) | This rule enforces the use of \<\>\.\.\.\</\> over \<Fragment\>\.\.\.\</Fragment\>\. |  |
+| [`useImportType`](https://biomejs.dev/linter/rules/use-import-type) | Promotes the use of import type for types\. |  |
+| [`useLiteralEnumMembers`](https://biomejs.dev/linter/rules/use-literal-enum-members) | Require all enum members to be literal values\. |  |
+| [`useNodeAssertStrict`](https://biomejs.dev/linter/rules/use-node-assert-strict) | Promotes the usage of node:assert/strict over node:assert\. |  |
+| [`useNodejsImportProtocol`](https://biomejs.dev/linter/rules/use-nodejs-import-protocol) | Enforces using the node: protocol for Node\.js builtin modules\. |  |
+| [`useNumberNamespace`](https://biomejs.dev/linter/rules/use-number-namespace) | Use the Number properties instead of global ones\. |  |
+| [`useNumericLiterals`](https://biomejs.dev/linter/rules/use-numeric-literals) | Disallow parseInt\(\) and Number\.parseInt\(\) in favor of binary, octal, and hexadecimal literals |  |
 | [`useSelfClosingElements`](https://biomejs.dev/linter/rules/use-self-closing-elements) | Prevent extra closing tags for components without children |  |
-| [`useShorthandArrayType`](https://biomejs.dev/linter/rules/use-shorthand-array-type) | When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>. |  |
-| [`useShorthandAssign`](https://biomejs.dev/linter/rules/use-shorthand-assign) | Require assignment operator shorthand where possible. |  |
-| [`useShorthandFunctionType`](https://biomejs.dev/linter/rules/use-shorthand-function-type) | Enforce using function types instead of object type with call signatures. |  |
-| [`useSingleCaseStatement`](https://biomejs.dev/linter/rules/use-single-case-statement) | Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block. |  |
+| [`useShorthandArrayType`](https://biomejs.dev/linter/rules/use-shorthand-array-type) | When expressing array types, this rule promotes the usage of T\[\] shorthand instead of Array\<T\>\. |  |
+| [`useShorthandAssign`](https://biomejs.dev/linter/rules/use-shorthand-assign) | Require assignment operator shorthand where possible\. |  |
+| [`useShorthandFunctionType`](https://biomejs.dev/linter/rules/use-shorthand-function-type) | Enforce using function types instead of object type with call signatures\. |  |
+| [`useSingleCaseStatement`](https://biomejs.dev/linter/rules/use-single-case-statement) | Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block\. |  |
 | [`useSingleVarDeclarator`](https://biomejs.dev/linter/rules/use-single-var-declarator) | Disallow multiple variable declarations in the same variable statement |  |
-| [`useTemplate`](https://biomejs.dev/linter/rules/use-template) | Prefer template literals over string concatenation. |  |
-| [`useThrowNewError`](https://biomejs.dev/linter/rules/use-throw-new-error) | Require new when throwing an error. |  |
-| [`useThrowOnlyError`](https://biomejs.dev/linter/rules/use-throw-only-error) | Disallow throwing non-Error values. |  |
-| [`useWhile`](https://biomejs.dev/linter/rules/use-while) | Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed. |  |
+| [`useTemplate`](https://biomejs.dev/linter/rules/use-template) | Prefer template literals over string concatenation\. |  |
+| [`useThrowNewError`](https://biomejs.dev/linter/rules/use-throw-new-error) | Require new when throwing an error\. |  |
+| [`useThrowOnlyError`](https://biomejs.dev/linter/rules/use-throw-only-error) | Disallow throwing non\-Error values\. |  |
+| [`useWhile`](https://biomejs.dev/linter/rules/use-while) | Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed\. |  |
 
 ---
 
@@ -285,72 +285,72 @@ Rules in this category identify potentially problematic code patterns.
 
 | Rule | Description | Options |
 | ---- | ----------- | ------- |
-| [`noApproximativeNumericConstant`](https://biomejs.dev/linter/rules/no-approximative-numeric-constant) | Use standard constants instead of approximated literals. |  |
-| [`noArrayIndexKey`](https://biomejs.dev/linter/rules/no-array-index-key) | Discourage the usage of Array index in keys. |  |
-| [`noAssignInExpressions`](https://biomejs.dev/linter/rules/no-assign-in-expressions) | Disallow assignments in expressions. |  |
-| [`noAsyncPromiseExecutor`](https://biomejs.dev/linter/rules/no-async-promise-executor) | Disallows using an async function as a Promise executor. |  |
-| [`noCatchAssign`](https://biomejs.dev/linter/rules/no-catch-assign) | Disallow reassigning exceptions in catch clauses. |  |
-| [`noClassAssign`](https://biomejs.dev/linter/rules/no-class-assign) | Disallow reassigning class members. |  |
+| [`noApproximativeNumericConstant`](https://biomejs.dev/linter/rules/no-approximative-numeric-constant) | Use standard constants instead of approximated literals\. |  |
+| [`noArrayIndexKey`](https://biomejs.dev/linter/rules/no-array-index-key) | Discourage the usage of Array index in keys\. |  |
+| [`noAssignInExpressions`](https://biomejs.dev/linter/rules/no-assign-in-expressions) | Disallow assignments in expressions\. |  |
+| [`noAsyncPromiseExecutor`](https://biomejs.dev/linter/rules/no-async-promise-executor) | Disallows using an async function as a Promise executor\. |  |
+| [`noCatchAssign`](https://biomejs.dev/linter/rules/no-catch-assign) | Disallow reassigning exceptions in catch clauses\. |  |
+| [`noClassAssign`](https://biomejs.dev/linter/rules/no-class-assign) | Disallow reassigning class members\. |  |
 | [`noCommentText`](https://biomejs.dev/linter/rules/no-comment-text) | Prevent comments from being inserted as text nodes |  |
-| [`noCompareNegZero`](https://biomejs.dev/linter/rules/no-compare-neg-zero) | Disallow comparing against -0 |  |
-| [`noConfusingLabels`](https://biomejs.dev/linter/rules/no-confusing-labels) | Disallow labeled statements that are not loops. |  |
-| [`noConfusingVoidType`](https://biomejs.dev/linter/rules/no-confusing-void-type) | Disallow void type outside of generic or return types. |  |
-| [`noConsole`](https://biomejs.dev/linter/rules/no-console) | Disallow the use of console. |  |
-| [`noConsoleLog`](https://biomejs.dev/linter/rules/no-console-log) | Disallow the use of console.log |  |
+| [`noCompareNegZero`](https://biomejs.dev/linter/rules/no-compare-neg-zero) | Disallow comparing against \-0 |  |
+| [`noConfusingLabels`](https://biomejs.dev/linter/rules/no-confusing-labels) | Disallow labeled statements that are not loops\. |  |
+| [`noConfusingVoidType`](https://biomejs.dev/linter/rules/no-confusing-void-type) | Disallow void type outside of generic or return types\. |  |
+| [`noConsole`](https://biomejs.dev/linter/rules/no-console) | Disallow the use of console\. |  |
+| [`noConsoleLog`](https://biomejs.dev/linter/rules/no-console-log) | Disallow the use of console\.log |  |
 | [`noConstEnum`](https://biomejs.dev/linter/rules/no-const-enum) | Disallow TypeScript const enum |  |
-| [`noControlCharactersInRegex`](https://biomejs.dev/linter/rules/no-control-characters-in-regex) | Prevents from having control characters and some escape sequences that match control characters in regular expressions. |  |
+| [`noControlCharactersInRegex`](https://biomejs.dev/linter/rules/no-control-characters-in-regex) | Prevents from having control characters and some escape sequences that match control characters in regular expressions\. |  |
 | [`noDebugger`](https://biomejs.dev/linter/rules/no-debugger) | Disallow the use of debugger |  |
-| [`noDoubleEquals`](https://biomejs.dev/linter/rules/no-double-equals) | Require the use of === and !==. |  |
-| [`noDuplicateAtImportRules`](https://biomejs.dev/linter/rules/no-duplicate-at-import-rules) | Disallow duplicate @import rules. |  |
-| [`noDuplicateCase`](https://biomejs.dev/linter/rules/no-duplicate-case) | Disallow duplicate case labels. |  |
-| [`noDuplicateClassMembers`](https://biomejs.dev/linter/rules/no-duplicate-class-members) | Disallow duplicate class members. |  |
-| [`noDuplicateFontNames`](https://biomejs.dev/linter/rules/no-duplicate-font-names) | Disallow duplicate names within font families. |  |
-| [`noDuplicateJsxProps`](https://biomejs.dev/linter/rules/no-duplicate-jsx-props) | Prevents JSX properties to be assigned multiple times. |  |
-| [`noDuplicateObjectKeys`](https://biomejs.dev/linter/rules/no-duplicate-object-keys) | Disallow two keys with the same name inside objects. |  |
-| [`noDuplicateParameters`](https://biomejs.dev/linter/rules/no-duplicate-parameters) | Disallow duplicate function parameter name. |  |
-| [`noDuplicateSelectorsKeyframeBlock`](https://biomejs.dev/linter/rules/no-duplicate-selectors-keyframe-block) | Disallow duplicate selectors within keyframe blocks. |  |
-| [`noDuplicateTestHooks`](https://biomejs.dev/linter/rules/no-duplicate-test-hooks) | A describe block should not contain duplicate hooks. |  |
-| [`noEmptyBlock`](https://biomejs.dev/linter/rules/no-empty-block) | Disallow CSS empty blocks. |  |
-| [`noEmptyBlockStatements`](https://biomejs.dev/linter/rules/no-empty-block-statements) | Disallow empty block statements and static blocks. |  |
-| [`noEmptyInterface`](https://biomejs.dev/linter/rules/no-empty-interface) | Disallow the declaration of empty interfaces. |  |
-| [`noEvolvingTypes`](https://biomejs.dev/linter/rules/no-evolving-types) | Disallow variables from evolving into any type through reassignments. |  |
-| [`noExplicitAny`](https://biomejs.dev/linter/rules/no-explicit-any) | Disallow the any type usage. |  |
-| [`noExportsInTest`](https://biomejs.dev/linter/rules/no-exports-in-test) | Disallow using export or module.exports in files containing tests |  |
-| [`noExtraNonNullAssertion`](https://biomejs.dev/linter/rules/no-extra-non-null-assertion) | Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files. |  |
-| [`noFallthroughSwitchClause`](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause) | Disallow fallthrough of switch clauses. |  |
-| [`noFocusedTests`](https://biomejs.dev/linter/rules/no-focused-tests) | Disallow focused tests. |  |
-| [`noFunctionAssign`](https://biomejs.dev/linter/rules/no-function-assign) | Disallow reassigning function declarations. |  |
-| [`noGlobalAssign`](https://biomejs.dev/linter/rules/no-global-assign) | Disallow assignments to native objects and read-only global variables. |  |
-| [`noGlobalIsFinite`](https://biomejs.dev/linter/rules/no-global-is-finite) | Use Number.isFinite instead of global isFinite. |  |
-| [`noGlobalIsNan`](https://biomejs.dev/linter/rules/no-global-is-nan) | Use Number.isNaN instead of global isNaN. |  |
-| [`noImplicitAnyLet`](https://biomejs.dev/linter/rules/no-implicit-any-let) | Disallow use of implicit any type on variable declarations. |  |
-| [`noImportantInKeyframe`](https://biomejs.dev/linter/rules/no-important-in-keyframe) | Disallow invalid !important within keyframe declarations |  |
+| [`noDoubleEquals`](https://biomejs.dev/linter/rules/no-double-equals) | Require the use of === and \!==\. |  |
+| [`noDuplicateAtImportRules`](https://biomejs.dev/linter/rules/no-duplicate-at-import-rules) | Disallow duplicate @import rules\. |  |
+| [`noDuplicateCase`](https://biomejs.dev/linter/rules/no-duplicate-case) | Disallow duplicate case labels\. |  |
+| [`noDuplicateClassMembers`](https://biomejs.dev/linter/rules/no-duplicate-class-members) | Disallow duplicate class members\. |  |
+| [`noDuplicateFontNames`](https://biomejs.dev/linter/rules/no-duplicate-font-names) | Disallow duplicate names within font families\. |  |
+| [`noDuplicateJsxProps`](https://biomejs.dev/linter/rules/no-duplicate-jsx-props) | Prevents JSX properties to be assigned multiple times\. |  |
+| [`noDuplicateObjectKeys`](https://biomejs.dev/linter/rules/no-duplicate-object-keys) | Disallow two keys with the same name inside objects\. |  |
+| [`noDuplicateParameters`](https://biomejs.dev/linter/rules/no-duplicate-parameters) | Disallow duplicate function parameter name\. |  |
+| [`noDuplicateSelectorsKeyframeBlock`](https://biomejs.dev/linter/rules/no-duplicate-selectors-keyframe-block) | Disallow duplicate selectors within keyframe blocks\. |  |
+| [`noDuplicateTestHooks`](https://biomejs.dev/linter/rules/no-duplicate-test-hooks) | A describe block should not contain duplicate hooks\. |  |
+| [`noEmptyBlock`](https://biomejs.dev/linter/rules/no-empty-block) | Disallow CSS empty blocks\. |  |
+| [`noEmptyBlockStatements`](https://biomejs.dev/linter/rules/no-empty-block-statements) | Disallow empty block statements and static blocks\. |  |
+| [`noEmptyInterface`](https://biomejs.dev/linter/rules/no-empty-interface) | Disallow the declaration of empty interfaces\. |  |
+| [`noEvolvingTypes`](https://biomejs.dev/linter/rules/no-evolving-types) | Disallow variables from evolving into any type through reassignments\. |  |
+| [`noExplicitAny`](https://biomejs.dev/linter/rules/no-explicit-any) | Disallow the any type usage\. |  |
+| [`noExportsInTest`](https://biomejs.dev/linter/rules/no-exports-in-test) | Disallow using export or module\.exports in files containing tests |  |
+| [`noExtraNonNullAssertion`](https://biomejs.dev/linter/rules/no-extra-non-null-assertion) | Prevents the wrong usage of the non\-null assertion operator \(\!\) in TypeScript files\. |  |
+| [`noFallthroughSwitchClause`](https://biomejs.dev/linter/rules/no-fallthrough-switch-clause) | Disallow fallthrough of switch clauses\. |  |
+| [`noFocusedTests`](https://biomejs.dev/linter/rules/no-focused-tests) | Disallow focused tests\. |  |
+| [`noFunctionAssign`](https://biomejs.dev/linter/rules/no-function-assign) | Disallow reassigning function declarations\. |  |
+| [`noGlobalAssign`](https://biomejs.dev/linter/rules/no-global-assign) | Disallow assignments to native objects and read\-only global variables\. |  |
+| [`noGlobalIsFinite`](https://biomejs.dev/linter/rules/no-global-is-finite) | Use Number\.isFinite instead of global isFinite\. |  |
+| [`noGlobalIsNan`](https://biomejs.dev/linter/rules/no-global-is-nan) | Use Number\.isNaN instead of global isNaN\. |  |
+| [`noImplicitAnyLet`](https://biomejs.dev/linter/rules/no-implicit-any-let) | Disallow use of implicit any type on variable declarations\. |  |
+| [`noImportantInKeyframe`](https://biomejs.dev/linter/rules/no-important-in-keyframe) | Disallow invalid \!important within keyframe declarations |  |
 | [`noImportAssign`](https://biomejs.dev/linter/rules/no-import-assign) | Disallow assigning to imported bindings |  |
 | [`noLabelVar`](https://biomejs.dev/linter/rules/no-label-var) | Disallow labels that share a name with a variable |  |
-| [`noMisleadingCharacterClass`](https://biomejs.dev/linter/rules/no-misleading-character-class) | Disallow characters made with multiple code points in character class syntax. |  |
-| [`noMisleadingInstantiator`](https://biomejs.dev/linter/rules/no-misleading-instantiator) | Enforce proper usage of new and constructor. |  |
-| [`noMisplacedAssertion`](https://biomejs.dev/linter/rules/no-misplaced-assertion) | Checks that the assertion function, for example expect, is placed inside an it() function call. |  |
-| [`noMisrefactoredShorthandAssign`](https://biomejs.dev/linter/rules/no-misrefactored-shorthand-assign) | Disallow shorthand assign when variable appears on both sides. |  |
-| [`noPrototypeBuiltins`](https://biomejs.dev/linter/rules/no-prototype-builtins) | Disallow direct use of Object.prototype builtins. |  |
-| [`noReactSpecificProps`](https://biomejs.dev/linter/rules/no-react-specific-props) | Prevents React-specific JSX properties from being used. |  |
-| [`noRedeclare`](https://biomejs.dev/linter/rules/no-redeclare) | Disallow variable, function, class, and type redeclarations in the same scope. |  |
-| [`noRedundantUseStrict`](https://biomejs.dev/linter/rules/no-redundant-use-strict) | Prevents from having redundant "use strict". |  |
-| [`noSelfCompare`](https://biomejs.dev/linter/rules/no-self-compare) | Disallow comparisons where both sides are exactly the same. |  |
-| [`noShadowRestrictedNames`](https://biomejs.dev/linter/rules/no-shadow-restricted-names) | Disallow identifiers from shadowing restricted names. |  |
-| [`noShorthandPropertyOverrides`](https://biomejs.dev/linter/rules/no-shorthand-property-overrides) | Disallow shorthand properties that override related longhand properties. |  |
-| [`noSkippedTests`](https://biomejs.dev/linter/rules/no-skipped-tests) | Disallow disabled tests. |  |
+| [`noMisleadingCharacterClass`](https://biomejs.dev/linter/rules/no-misleading-character-class) | Disallow characters made with multiple code points in character class syntax\. |  |
+| [`noMisleadingInstantiator`](https://biomejs.dev/linter/rules/no-misleading-instantiator) | Enforce proper usage of new and constructor\. |  |
+| [`noMisplacedAssertion`](https://biomejs.dev/linter/rules/no-misplaced-assertion) | Checks that the assertion function, for example expect, is placed inside an it\(\) function call\. |  |
+| [`noMisrefactoredShorthandAssign`](https://biomejs.dev/linter/rules/no-misrefactored-shorthand-assign) | Disallow shorthand assign when variable appears on both sides\. |  |
+| [`noPrototypeBuiltins`](https://biomejs.dev/linter/rules/no-prototype-builtins) | Disallow direct use of Object\.prototype builtins\. |  |
+| [`noReactSpecificProps`](https://biomejs.dev/linter/rules/no-react-specific-props) | Prevents React\-specific JSX properties from being used\. |  |
+| [`noRedeclare`](https://biomejs.dev/linter/rules/no-redeclare) | Disallow variable, function, class, and type redeclarations in the same scope\. |  |
+| [`noRedundantUseStrict`](https://biomejs.dev/linter/rules/no-redundant-use-strict) | Prevents from having redundant "use strict"\. |  |
+| [`noSelfCompare`](https://biomejs.dev/linter/rules/no-self-compare) | Disallow comparisons where both sides are exactly the same\. |  |
+| [`noShadowRestrictedNames`](https://biomejs.dev/linter/rules/no-shadow-restricted-names) | Disallow identifiers from shadowing restricted names\. |  |
+| [`noShorthandPropertyOverrides`](https://biomejs.dev/linter/rules/no-shorthand-property-overrides) | Disallow shorthand properties that override related longhand properties\. |  |
+| [`noSkippedTests`](https://biomejs.dev/linter/rules/no-skipped-tests) | Disallow disabled tests\. |  |
 | [`noSparseArray`](https://biomejs.dev/linter/rules/no-sparse-array) | Disallow sparse arrays |  |
-| [`noSuspiciousSemicolonInJsx`](https://biomejs.dev/linter/rules/no-suspicious-semicolon-in-jsx) | It detects possible “wrong” semicolons inside JSX elements. |  |
-| [`noThenProperty`](https://biomejs.dev/linter/rules/no-then-property) | Disallow then property. |  |
-| [`noUnsafeDeclarationMerging`](https://biomejs.dev/linter/rules/no-unsafe-declaration-merging) | Disallow unsafe declaration merging between interfaces and classes. |  |
-| [`noUnsafeNegation`](https://biomejs.dev/linter/rules/no-unsafe-negation) | Disallow using unsafe negation. |  |
-| [`useAwait`](https://biomejs.dev/linter/rules/use-await) | Ensure async functions utilize await. |  |
+| [`noSuspiciousSemicolonInJsx`](https://biomejs.dev/linter/rules/no-suspicious-semicolon-in-jsx) | It detects possible “wrong” semicolons inside JSX elements\. |  |
+| [`noThenProperty`](https://biomejs.dev/linter/rules/no-then-property) | Disallow then property\. |  |
+| [`noUnsafeDeclarationMerging`](https://biomejs.dev/linter/rules/no-unsafe-declaration-merging) | Disallow unsafe declaration merging between interfaces and classes\. |  |
+| [`noUnsafeNegation`](https://biomejs.dev/linter/rules/no-unsafe-negation) | Disallow using unsafe negation\. |  |
+| [`useAwait`](https://biomejs.dev/linter/rules/use-await) | Ensure async functions utilize await\. |  |
 | [`useDefaultSwitchClauseLast`](https://biomejs.dev/linter/rules/use-default-switch-clause-last) | Enforce default clauses in switch statements to be last |  |
-| [`useErrorMessage`](https://biomejs.dev/linter/rules/use-error-message) | Enforce passing a message value when creating a built-in error. |  |
-| [`useGetterReturn`](https://biomejs.dev/linter/rules/use-getter-return) | Enforce get methods to always return a value. |  |
-| [`useIsArray`](https://biomejs.dev/linter/rules/use-is-array) | Use Array.isArray() instead of instanceof Array. |  |
-| [`useNamespaceKeyword`](https://biomejs.dev/linter/rules/use-namespace-keyword) | Require using the namespace keyword over the module keyword to declare TypeScript namespaces. |  |
-| [`useNumberToFixedDigitsArgument`](https://biomejs.dev/linter/rules/use-number-to-fixed-digits-argument) | Enforce using the digits argument with Number#toFixed(). |  |
+| [`useErrorMessage`](https://biomejs.dev/linter/rules/use-error-message) | Enforce passing a message value when creating a built\-in error\. |  |
+| [`useGetterReturn`](https://biomejs.dev/linter/rules/use-getter-return) | Enforce get methods to always return a value\. |  |
+| [`useIsArray`](https://biomejs.dev/linter/rules/use-is-array) | Use Array\.isArray\(\) instead of instanceof Array\. |  |
+| [`useNamespaceKeyword`](https://biomejs.dev/linter/rules/use-namespace-keyword) | Require using the namespace keyword over the module keyword to declare TypeScript namespaces\. |  |
+| [`useNumberToFixedDigitsArgument`](https://biomejs.dev/linter/rules/use-number-to-fixed-digits-argument) | Enforce using the digits argument with Number\#toFixed\(\)\. |  |
 | [`useValidTypeof`](https://biomejs.dev/linter/rules/use-valid-typeof) | This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions |  |
 
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "fmt:rulens": "node dist/index.js generate",
     "fmt:syncpack-fix": "syncpack fix-mismatches",
     "fmt:syncpack-format": "syncpack format",
-    "lint": "pnpm run lint:biome && pnpm run lint:tsc && pnpm run lint:syncpack && pnpm run lint:eslint && pnpm run lint:knip",
+    "lint": "pnpm run lint:biome && pnpm run lint:tsc && pnpm run lint:syncpack && pnpm run lint:eslint && pnpm run lint:knip && pnpm run lint:rulens",
     "lint:biome": "biome check . --log-level=warn",
     "lint:eslint": "eslint .",
     "lint:knip": "knip",

--- a/scripts/crawl-biome-rules.ts
+++ b/scripts/crawl-biome-rules.ts
@@ -88,6 +88,8 @@ function extractRulesFromTable(
     // Parse rule information
     const ruleInfo = extractRuleInfo($, cells, categoryName)
     if (ruleInfo) {
+      // Escape special characters in description to prevent breaking Markdown rendering
+      ruleInfo.description = escapeMarkdownSpecialChars(ruleInfo.description)
       result.push(ruleInfo)
     }
   }
@@ -157,6 +159,28 @@ async function extractRuleInformation(): Promise<BiomeRuleDescription> {
   }
 
   return descriptions
+}
+
+/**
+ * Escape special Markdown characters in a string to prevent rendering issues
+ */
+function escapeMarkdownSpecialChars(str: string): string {
+  return str
+    .replace(/</g, '\\<')
+    .replace(/>/g, '\\>')
+    .replace(/\|/g, '\\|')
+    .replace(/\*/g, '\\*')
+    .replace(/_/g, '\\_')
+    .replace(/`/g, '\\`')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/#/g, '\\#')
+    .replace(/\+/g, '\\+')
+    .replace(/-/g, '\\-')
+    .replace(/\./g, '\\.')
+    .replace(/!/g, '\\!')
 }
 
 /**

--- a/src/data/biome-rules.json
+++ b/src/data/biome-rules.json
@@ -1,46 +1,46 @@
 {
   "a11y/noAccessKey": {
-    "description": "Enforce that the accessKey attribute is not used on any HTML element.",
+    "description": "Enforce that the accessKey attribute is not used on any HTML element\\.",
     "url": "https://biomejs.dev/linter/rules/no-access-key"
   },
   "a11y/noAriaHiddenOnFocusable": {
-    "description": "Enforce that aria-hidden=“true” is not set on focusable elements.",
+    "description": "Enforce that aria\\-hidden=“true” is not set on focusable elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-aria-hidden-on-focusable"
   },
   "a11y/noAriaUnsupportedElements": {
-    "description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.",
+    "description": "Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes\\.",
     "url": "https://biomejs.dev/linter/rules/no-aria-unsupported-elements"
   },
   "a11y/noAutofocus": {
-    "description": "Enforce that autoFocus prop is not used on elements.",
+    "description": "Enforce that autoFocus prop is not used on elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-autofocus"
   },
   "a11y/noBlankTarget": {
-    "description": "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"",
+    "description": "Disallow target=\"\\_blank\" attribute without rel=\"noreferrer\"",
     "url": "https://biomejs.dev/linter/rules/no-blank-target"
   },
   "a11y/noDistractingElements": {
-    "description": "Enforces that no distracting elements are used.",
+    "description": "Enforces that no distracting elements are used\\.",
     "url": "https://biomejs.dev/linter/rules/no-distracting-elements"
   },
   "a11y/noHeaderScope": {
-    "description": "The scope prop should be used only on <th> elements.",
+    "description": "The scope prop should be used only on \\<th\\> elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-header-scope"
   },
   "a11y/noInteractiveElementToNoninteractiveRole": {
-    "description": "Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.",
+    "description": "Enforce that non\\-interactive ARIA roles are not assigned to interactive HTML elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-interactive-element-to-noninteractive-role"
   },
   "a11y/noLabelWithoutControl": {
-    "description": "Enforce that a label element or component has a text label and an associated input.",
+    "description": "Enforce that a label element or component has a text label and an associated input\\.",
     "url": "https://biomejs.dev/linter/rules/no-label-without-control"
   },
   "a11y/noNoninteractiveElementToInteractiveRole": {
-    "description": "Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.",
+    "description": "Enforce that interactive ARIA roles are not assigned to non\\-interactive HTML elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-noninteractive-element-to-interactive-role"
   },
   "a11y/noNoninteractiveTabindex": {
-    "description": "Enforce that tabIndex is not assigned to non-interactive HTML elements.",
+    "description": "Enforce that tabIndex is not assigned to non\\-interactive HTML elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-noninteractive-tabindex"
   },
   "a11y/noPositiveTabindex": {
@@ -48,31 +48,31 @@
     "url": "https://biomejs.dev/linter/rules/no-positive-tabindex"
   },
   "a11y/noRedundantAlt": {
-    "description": "Enforce img alt prop does not contain the word “image”, “picture”, or “photo”.",
+    "description": "Enforce img alt prop does not contain the word “image”, “picture”, or “photo”\\.",
     "url": "https://biomejs.dev/linter/rules/no-redundant-alt"
   },
   "a11y/noRedundantRoles": {
-    "description": "Enforce explicit role property is not the same as implicit/default role property on an element.",
+    "description": "Enforce explicit role property is not the same as implicit/default role property on an element\\.",
     "url": "https://biomejs.dev/linter/rules/no-redundant-roles"
   },
   "a11y/noSvgWithoutTitle": {
-    "description": "Enforces the usage of the title element for the svg element.",
+    "description": "Enforces the usage of the title element for the svg element\\.",
     "url": "https://biomejs.dev/linter/rules/no-svg-without-title"
   },
   "a11y/useAltText": {
-    "description": "Enforce that all elements that require alternative text have meaningful information to relay back to the end user.",
+    "description": "Enforce that all elements that require alternative text have meaningful information to relay back to the end user\\.",
     "url": "https://biomejs.dev/linter/rules/use-alt-text"
   },
   "a11y/useAnchorContent": {
-    "description": "Enforce that anchors have content and that the content is accessible to screen readers.",
+    "description": "Enforce that anchors have content and that the content is accessible to screen readers\\.",
     "url": "https://biomejs.dev/linter/rules/use-anchor-content"
   },
   "a11y/useAriaActivedescendantWithTabindex": {
-    "description": "Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.",
+    "description": "Enforce that tabIndex is assigned to non\\-interactive HTML elements with aria\\-activedescendant\\.",
     "url": "https://biomejs.dev/linter/rules/use-aria-activedescendant-with-tabindex"
   },
   "a11y/useAriaPropsForRole": {
-    "description": "Enforce that elements with ARIA roles must have all required ARIA attributes for that role.",
+    "description": "Enforce that elements with ARIA roles must have all required ARIA attributes for that role\\.",
     "url": "https://biomejs.dev/linter/rules/use-aria-props-for-role"
   },
   "a11y/useButtonType": {
@@ -80,75 +80,75 @@
     "url": "https://biomejs.dev/linter/rules/use-button-type"
   },
   "a11y/useFocusableInteractive": {
-    "description": "Elements with an interactive role and interaction handlers must be focusable.",
+    "description": "Elements with an interactive role and interaction handlers must be focusable\\.",
     "url": "https://biomejs.dev/linter/rules/use-focusable-interactive"
   },
   "a11y/useGenericFontNames": {
-    "description": "Disallow a missing generic family keyword within font families.",
+    "description": "Disallow a missing generic family keyword within font families\\.",
     "url": "https://biomejs.dev/linter/rules/use-generic-font-names"
   },
   "a11y/useHeadingContent": {
-    "description": "Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.",
+    "description": "Enforce that heading elements \\(h1, h2, etc\\.\\) have content and that the content is accessible to screen readers\\. Accessible means that it is not hidden using the aria\\-hidden prop\\.",
     "url": "https://biomejs.dev/linter/rules/use-heading-content"
   },
   "a11y/useHtmlLang": {
-    "description": "Enforce that html element has lang attribute.",
+    "description": "Enforce that html element has lang attribute\\.",
     "url": "https://biomejs.dev/linter/rules/use-html-lang"
   },
   "a11y/useIframeTitle": {
-    "description": "Enforces the usage of the attribute title for the element iframe.",
+    "description": "Enforces the usage of the attribute title for the element iframe\\.",
     "url": "https://biomejs.dev/linter/rules/use-iframe-title"
   },
   "a11y/useKeyWithClickEvents": {
-    "description": "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress.",
+    "description": "Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress\\.",
     "url": "https://biomejs.dev/linter/rules/use-key-with-click-events"
   },
   "a11y/useKeyWithMouseEvents": {
-    "description": "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur.",
+    "description": "Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur\\.",
     "url": "https://biomejs.dev/linter/rules/use-key-with-mouse-events"
   },
   "a11y/useMediaCaption": {
-    "description": "Enforces that audio and video elements must have a track for captions.",
+    "description": "Enforces that audio and video elements must have a track for captions\\.",
     "url": "https://biomejs.dev/linter/rules/use-media-caption"
   },
   "a11y/useSemanticElements": {
-    "description": "It detects the use of role attributes in JSX elements and suggests using semantic elements instead.",
+    "description": "It detects the use of role attributes in JSX elements and suggests using semantic elements instead\\.",
     "url": "https://biomejs.dev/linter/rules/use-semantic-elements"
   },
   "a11y/useValidAnchor": {
-    "description": "Enforce that all anchors are valid, and they are navigable elements.",
+    "description": "Enforce that all anchors are valid, and they are navigable elements\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-anchor"
   },
   "a11y/useValidAriaProps": {
-    "description": "Ensures that ARIA properties aria-* are all valid.",
+    "description": "Ensures that ARIA properties aria\\-\\* are all valid\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-aria-props"
   },
   "a11y/useValidAriaRole": {
-    "description": "Elements with ARIA roles must use a valid, non-abstract ARIA role.",
+    "description": "Elements with ARIA roles must use a valid, non\\-abstract ARIA role\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-aria-role"
   },
   "a11y/useValidAriaValues": {
-    "description": "Enforce that ARIA state and property values are valid.",
+    "description": "Enforce that ARIA state and property values are valid\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-aria-values"
   },
   "a11y/useValidLang": {
-    "description": "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country.",
+    "description": "Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-lang"
   },
   "Complexity/noBannedTypes": {
-    "description": "Disallow primitive type aliases and misleading types.",
+    "description": "Disallow primitive type aliases and misleading types\\.",
     "url": "https://biomejs.dev/linter/rules/no-banned-types"
   },
   "Complexity/noEmptyTypeParameters": {
-    "description": "Disallow empty type parameters in type aliases and interfaces.",
+    "description": "Disallow empty type parameters in type aliases and interfaces\\.",
     "url": "https://biomejs.dev/linter/rules/no-empty-type-parameters"
   },
   "Complexity/noExcessiveCognitiveComplexity": {
-    "description": "Disallow functions that exceed a given Cognitive Complexity score.",
+    "description": "Disallow functions that exceed a given Cognitive Complexity score\\.",
     "url": "https://biomejs.dev/linter/rules/no-excessive-cognitive-complexity"
   },
   "Complexity/noExcessiveNestedTestSuites": {
-    "description": "This rule enforces a maximum depth to nested describe() in test files.",
+    "description": "This rule enforces a maximum depth to nested describe\\(\\) in test files\\.",
     "url": "https://biomejs.dev/linter/rules/no-excessive-nested-test-suites"
   },
   "Complexity/noExtraBooleanCast": {
@@ -156,7 +156,7 @@
     "url": "https://biomejs.dev/linter/rules/no-extra-boolean-cast"
   },
   "Complexity/noForEach": {
-    "description": "Prefer for...of statement instead of Array.forEach.",
+    "description": "Prefer for\\.\\.\\.of statement instead of Array\\.forEach\\.",
     "url": "https://biomejs.dev/linter/rules/no-for-each"
   },
   "Complexity/noMultipleSpacesInRegularExpressionLiterals": {
@@ -164,23 +164,23 @@
     "url": "https://biomejs.dev/linter/rules/no-multiple-spaces-in-regular-expression-literals"
   },
   "Complexity/noStaticOnlyClass": {
-    "description": "This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.",
+    "description": "This rule reports when a class has no non\\-static members, such as for a class used exclusively as a static namespace\\.",
     "url": "https://biomejs.dev/linter/rules/no-static-only-class"
   },
   "Complexity/noThisInStatic": {
-    "description": "Disallow this and super in static contexts.",
+    "description": "Disallow this and super in static contexts\\.",
     "url": "https://biomejs.dev/linter/rules/no-this-in-static"
   },
   "Complexity/noUselessCatch": {
-    "description": "Disallow unnecessary catch clauses.",
+    "description": "Disallow unnecessary catch clauses\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-catch"
   },
   "Complexity/noUselessConstructor": {
-    "description": "Disallow unnecessary constructors.",
+    "description": "Disallow unnecessary constructors\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-constructor"
   },
   "Complexity/noUselessEmptyExport": {
-    "description": "Disallow empty exports that don’t change anything in a module file.",
+    "description": "Disallow empty exports that don’t change anything in a module file\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-empty-export"
   },
   "Complexity/noUselessFragments": {
@@ -188,71 +188,71 @@
     "url": "https://biomejs.dev/linter/rules/no-useless-fragments"
   },
   "Complexity/noUselessLabel": {
-    "description": "Disallow unnecessary labels.",
+    "description": "Disallow unnecessary labels\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-label"
   },
   "Complexity/noUselessLoneBlockStatements": {
-    "description": "Disallow unnecessary nested block statements.",
+    "description": "Disallow unnecessary nested block statements\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-lone-block-statements"
   },
   "Complexity/noUselessRename": {
-    "description": "Disallow renaming import, export, and destructured assignments to the same name.",
+    "description": "Disallow renaming import, export, and destructured assignments to the same name\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-rename"
   },
   "Complexity/noUselessStringConcat": {
-    "description": "Disallow unnecessary concatenation of string or template literals.",
+    "description": "Disallow unnecessary concatenation of string or template literals\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-string-concat"
   },
   "Complexity/noUselessSwitchCase": {
-    "description": "Disallow useless case in switch statements.",
+    "description": "Disallow useless case in switch statements\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-switch-case"
   },
   "Complexity/noUselessTernary": {
-    "description": "Disallow ternary operators when simpler alternatives exist.",
+    "description": "Disallow ternary operators when simpler alternatives exist\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-ternary"
   },
   "Complexity/noUselessThisAlias": {
-    "description": "Disallow useless this aliasing.",
+    "description": "Disallow useless this aliasing\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-this-alias"
   },
   "Complexity/noUselessTypeConstraint": {
-    "description": "Disallow using any or unknown as type constraint.",
+    "description": "Disallow using any or unknown as type constraint\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-type-constraint"
   },
   "Complexity/noUselessUndefinedInitialization": {
-    "description": "Disallow initializing variables to undefined.",
+    "description": "Disallow initializing variables to undefined\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-undefined-initialization"
   },
   "Complexity/noVoid": {
-    "description": "Disallow the use of void operators, which is not a familiar operator.",
+    "description": "Disallow the use of void operators, which is not a familiar operator\\.",
     "url": "https://biomejs.dev/linter/rules/no-void"
   },
   "Complexity/noWith": {
-    "description": "Disallow with statements in non-strict contexts.",
+    "description": "Disallow with statements in non\\-strict contexts\\.",
     "url": "https://biomejs.dev/linter/rules/no-with"
   },
   "Complexity/useArrowFunction": {
-    "description": "Use arrow functions over function expressions.",
+    "description": "Use arrow functions over function expressions\\.",
     "url": "https://biomejs.dev/linter/rules/use-arrow-function"
   },
   "Complexity/useDateNow": {
-    "description": "Use Date.now() to get the number of milliseconds since the Unix Epoch.",
+    "description": "Use Date\\.now\\(\\) to get the number of milliseconds since the Unix Epoch\\.",
     "url": "https://biomejs.dev/linter/rules/use-date-now"
   },
   "Complexity/useFlatMap": {
-    "description": "Promotes the use of .flatMap() when map().flat() are used together.",
+    "description": "Promotes the use of \\.flatMap\\(\\) when map\\(\\)\\.flat\\(\\) are used together\\.",
     "url": "https://biomejs.dev/linter/rules/use-flat-map"
   },
   "Complexity/useLiteralKeys": {
-    "description": "Enforce the usage of a literal access to properties over computed property access.",
+    "description": "Enforce the usage of a literal access to properties over computed property access\\.",
     "url": "https://biomejs.dev/linter/rules/use-literal-keys"
   },
   "Complexity/useOptionalChain": {
-    "description": "Enforce using concise optional chain instead of chained logical expressions.",
+    "description": "Enforce using concise optional chain instead of chained logical expressions\\.",
     "url": "https://biomejs.dev/linter/rules/use-optional-chain"
   },
   "Complexity/useRegexLiterals": {
-    "description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible.",
+    "description": "Enforce the use of the regular expression literals instead of the RegExp constructor if possible\\.",
     "url": "https://biomejs.dev/linter/rules/use-regex-literals"
   },
   "Complexity/useSimpleNumberKeys": {
@@ -260,15 +260,15 @@
     "url": "https://biomejs.dev/linter/rules/use-simple-number-keys"
   },
   "Complexity/useSimplifiedLogicExpression": {
-    "description": "Discard redundant terms from logical expressions.",
+    "description": "Discard redundant terms from logical expressions\\.",
     "url": "https://biomejs.dev/linter/rules/use-simplified-logic-expression"
   },
   "Correctness/noChildrenProp": {
-    "description": "Prevent passing of children as props.",
+    "description": "Prevent passing of children as props\\.",
     "url": "https://biomejs.dev/linter/rules/no-children-prop"
   },
   "Correctness/noConstAssign": {
-    "description": "Prevents from having const variables being re-assigned.",
+    "description": "Prevents from having const variables being re\\-assigned\\.",
     "url": "https://biomejs.dev/linter/rules/no-const-assign"
   },
   "Correctness/noConstantCondition": {
@@ -276,23 +276,23 @@
     "url": "https://biomejs.dev/linter/rules/no-constant-condition"
   },
   "Correctness/noConstantMathMinMaxClamp": {
-    "description": "Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant.",
+    "description": "Disallow the use of Math\\.min and Math\\.max to clamp a value where the result itself is constant\\.",
     "url": "https://biomejs.dev/linter/rules/no-constant-math-min-max-clamp"
   },
   "Correctness/noConstructorReturn": {
-    "description": "Disallow returning a value from a constructor.",
+    "description": "Disallow returning a value from a constructor\\.",
     "url": "https://biomejs.dev/linter/rules/no-constructor-return"
   },
   "Correctness/noEmptyCharacterClassInRegex": {
-    "description": "Disallow empty character classes in regular expression literals.",
+    "description": "Disallow empty character classes in regular expression literals\\.",
     "url": "https://biomejs.dev/linter/rules/no-empty-character-class-in-regex"
   },
   "Correctness/noEmptyPattern": {
-    "description": "Disallows empty destructuring patterns.",
+    "description": "Disallows empty destructuring patterns\\.",
     "url": "https://biomejs.dev/linter/rules/no-empty-pattern"
   },
   "Correctness/noFlatMapIdentity": {
-    "description": "Disallow to use unnecessary callback on flatMap.",
+    "description": "Disallow to use unnecessary callback on flatMap\\.",
     "url": "https://biomejs.dev/linter/rules/no-flat-map-identity"
   },
   "Correctness/noGlobalObjectCalls": {
@@ -300,31 +300,31 @@
     "url": "https://biomejs.dev/linter/rules/no-global-object-calls"
   },
   "Correctness/noInnerDeclarations": {
-    "description": "Disallow function and var declarations that are accessible outside their block.",
+    "description": "Disallow function and var declarations that are accessible outside their block\\.",
     "url": "https://biomejs.dev/linter/rules/no-inner-declarations"
   },
   "Correctness/noInvalidBuiltinInstantiation": {
-    "description": "Ensure that builtins are correctly instantiated.",
+    "description": "Ensure that builtins are correctly instantiated\\.",
     "url": "https://biomejs.dev/linter/rules/no-invalid-builtin-instantiation"
   },
   "Correctness/noInvalidConstructorSuper": {
-    "description": "Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.",
+    "description": "Prevents the incorrect use of super\\(\\) inside classes\\. It also checks whether a call super\\(\\) is missing from classes that extends other constructors\\.",
     "url": "https://biomejs.dev/linter/rules/no-invalid-constructor-super"
   },
   "Correctness/noInvalidDirectionInLinearGradient": {
-    "description": "Disallow non-standard direction values for linear gradient functions.",
+    "description": "Disallow non\\-standard direction values for linear gradient functions\\.",
     "url": "https://biomejs.dev/linter/rules/no-invalid-direction-in-linear-gradient"
   },
   "Correctness/noInvalidGridAreas": {
-    "description": "Disallows invalid named grid areas in CSS Grid Layouts.",
+    "description": "Disallows invalid named grid areas in CSS Grid Layouts\\.",
     "url": "https://biomejs.dev/linter/rules/no-invalid-grid-areas"
   },
   "Correctness/noInvalidNewBuiltin": {
-    "description": "Disallow new operators with global non-constructor functions.",
+    "description": "Disallow new operators with global non\\-constructor functions\\.",
     "url": "https://biomejs.dev/linter/rules/no-invalid-new-builtin"
   },
   "Correctness/noInvalidPositionAtImportRule": {
-    "description": "Disallow the use of @import at-rules in invalid positions.",
+    "description": "Disallow the use of @import at\\-rules in invalid positions\\.",
     "url": "https://biomejs.dev/linter/rules/no-invalid-position-at-import-rule"
   },
   "Correctness/noInvalidUseBeforeDeclaration": {
@@ -332,15 +332,15 @@
     "url": "https://biomejs.dev/linter/rules/no-invalid-use-before-declaration"
   },
   "Correctness/noNewSymbol": {
-    "description": "Disallow new operators with the Symbol object.",
+    "description": "Disallow new operators with the Symbol object\\.",
     "url": "https://biomejs.dev/linter/rules/no-new-symbol"
   },
   "Correctness/noNodejsModules": {
-    "description": "Forbid the use of Node.js builtin modules.",
+    "description": "Forbid the use of Node\\.js builtin modules\\.",
     "url": "https://biomejs.dev/linter/rules/no-nodejs-modules"
   },
   "Correctness/noNonoctalDecimalEscape": {
-    "description": "Disallow \\8 and \\9 escape sequences in string literals.",
+    "description": "Disallow \\8 and \\9 escape sequences in string literals\\.",
     "url": "https://biomejs.dev/linter/rules/no-nonoctal-decimal-escape"
   },
   "Correctness/noPrecisionLoss": {
@@ -348,11 +348,11 @@
     "url": "https://biomejs.dev/linter/rules/no-precision-loss"
   },
   "Correctness/noRenderReturnValue": {
-    "description": "Prevent the usage of the return value of React.render.",
+    "description": "Prevent the usage of the return value of React\\.render\\.",
     "url": "https://biomejs.dev/linter/rules/no-render-return-value"
   },
   "Correctness/noSelfAssign": {
-    "description": "Disallow assignments where both sides are exactly the same.",
+    "description": "Disallow assignments where both sides are exactly the same\\.",
     "url": "https://biomejs.dev/linter/rules/no-self-assign"
   },
   "Correctness/noSetterReturn": {
@@ -360,43 +360,43 @@
     "url": "https://biomejs.dev/linter/rules/no-setter-return"
   },
   "Correctness/noStringCaseMismatch": {
-    "description": "Disallow comparison of expressions modifying the string case with non-compliant value.",
+    "description": "Disallow comparison of expressions modifying the string case with non\\-compliant value\\.",
     "url": "https://biomejs.dev/linter/rules/no-string-case-mismatch"
   },
   "Correctness/noSwitchDeclarations": {
-    "description": "Disallow lexical declarations in switch clauses.",
+    "description": "Disallow lexical declarations in switch clauses\\.",
     "url": "https://biomejs.dev/linter/rules/no-switch-declarations"
   },
   "Correctness/noUndeclaredDependencies": {
-    "description": "Disallow the use of dependencies that aren’t specified in the package.json.",
+    "description": "Disallow the use of dependencies that aren’t specified in the package\\.json\\.",
     "url": "https://biomejs.dev/linter/rules/no-undeclared-dependencies"
   },
   "Correctness/noUndeclaredVariables": {
-    "description": "Prevents the usage of variables that haven’t been declared inside the document.",
+    "description": "Prevents the usage of variables that haven’t been declared inside the document\\.",
     "url": "https://biomejs.dev/linter/rules/no-undeclared-variables"
   },
   "Correctness/noUnknownFunction": {
-    "description": "Disallow unknown CSS value functions.",
+    "description": "Disallow unknown CSS value functions\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-function"
   },
   "Correctness/noUnknownMediaFeatureName": {
-    "description": "Disallow unknown media feature names.",
+    "description": "Disallow unknown media feature names\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-media-feature-name"
   },
   "Correctness/noUnknownProperty": {
-    "description": "Disallow unknown properties.",
+    "description": "Disallow unknown properties\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-property"
   },
   "Correctness/noUnknownUnit": {
-    "description": "Disallow unknown CSS units.",
+    "description": "Disallow unknown CSS units\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-unit"
   },
   "Correctness/noUnmatchableAnbSelector": {
-    "description": "Disallow unmatchable An+B selectors.",
+    "description": "Disallow unmatchable An\\+B selectors\\.",
     "url": "https://biomejs.dev/linter/rules/no-unmatchable-anb-selector"
   },
   "Correctness/noUnnecessaryContinue": {
-    "description": "Avoid using unnecessary continue.",
+    "description": "Avoid using unnecessary continue\\.",
     "url": "https://biomejs.dev/linter/rules/no-unnecessary-continue"
   },
   "Correctness/noUnreachable": {
@@ -404,27 +404,27 @@
     "url": "https://biomejs.dev/linter/rules/no-unreachable"
   },
   "Correctness/noUnreachableSuper": {
-    "description": "Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass",
+    "description": "Ensures the super\\(\\) constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass",
     "url": "https://biomejs.dev/linter/rules/no-unreachable-super"
   },
   "Correctness/noUnsafeFinally": {
-    "description": "Disallow control flow statements in finally blocks.",
+    "description": "Disallow control flow statements in finally blocks\\.",
     "url": "https://biomejs.dev/linter/rules/no-unsafe-finally"
   },
   "Correctness/noUnsafeOptionalChaining": {
-    "description": "Disallow the use of optional chaining in contexts where the undefined value is not allowed.",
+    "description": "Disallow the use of optional chaining in contexts where the undefined value is not allowed\\.",
     "url": "https://biomejs.dev/linter/rules/no-unsafe-optional-chaining"
   },
   "Correctness/noUnusedFunctionParameters": {
-    "description": "Disallow unused function parameters.",
+    "description": "Disallow unused function parameters\\.",
     "url": "https://biomejs.dev/linter/rules/no-unused-function-parameters"
   },
   "Correctness/noUnusedImports": {
-    "description": "Disallow unused imports.",
+    "description": "Disallow unused imports\\.",
     "url": "https://biomejs.dev/linter/rules/no-unused-imports"
   },
   "Correctness/noUnusedLabels": {
-    "description": "Disallow unused labels.",
+    "description": "Disallow unused labels\\.",
     "url": "https://biomejs.dev/linter/rules/no-unused-labels"
   },
   "Correctness/noUnusedPrivateClassMembers": {
@@ -432,11 +432,11 @@
     "url": "https://biomejs.dev/linter/rules/no-unused-private-class-members"
   },
   "Correctness/noUnusedVariables": {
-    "description": "Disallow unused variables.",
+    "description": "Disallow unused variables\\.",
     "url": "https://biomejs.dev/linter/rules/no-unused-variables"
   },
   "Correctness/noVoidElementsWithChildren": {
-    "description": "This rules prevents void elements (AKA self-closing elements) from having children.",
+    "description": "This rules prevents void elements \\(AKA self\\-closing elements\\) from having children\\.",
     "url": "https://biomejs.dev/linter/rules/no-void-elements-with-children"
   },
   "Correctness/noVoidTypeReturn": {
@@ -444,103 +444,103 @@
     "url": "https://biomejs.dev/linter/rules/no-void-type-return"
   },
   "Correctness/useArrayLiterals": {
-    "description": "Disallow Array constructors.",
+    "description": "Disallow Array constructors\\.",
     "url": "https://biomejs.dev/linter/rules/use-array-literals"
   },
   "Correctness/useExhaustiveDependencies": {
-    "description": "Enforce all dependencies are correctly specified in a React hook.",
+    "description": "Enforce all dependencies are correctly specified in a React hook\\.",
     "url": "https://biomejs.dev/linter/rules/use-exhaustive-dependencies"
   },
   "Correctness/useHookAtTopLevel": {
-    "description": "Enforce that all React hooks are being called from the Top Level component functions.",
+    "description": "Enforce that all React hooks are being called from the Top Level component functions\\.",
     "url": "https://biomejs.dev/linter/rules/use-hook-at-top-level"
   },
   "Correctness/useImportExtensions": {
-    "description": "Enforce file extensions for relative imports.",
+    "description": "Enforce file extensions for relative imports\\.",
     "url": "https://biomejs.dev/linter/rules/use-import-extensions"
   },
   "Correctness/useIsNan": {
-    "description": "Require calls to isNaN() when checking for NaN.",
+    "description": "Require calls to isNaN\\(\\) when checking for NaN\\.",
     "url": "https://biomejs.dev/linter/rules/use-is-nan"
   },
   "Correctness/useJsxKeyInIterable": {
-    "description": "Disallow missing key props in iterators/collection literals.",
+    "description": "Disallow missing key props in iterators/collection literals\\.",
     "url": "https://biomejs.dev/linter/rules/use-jsx-key-in-iterable"
   },
   "Correctness/useValidForDirection": {
-    "description": "Enforce “for” loop update clause moving the counter in the right direction.",
+    "description": "Enforce “for” loop update clause moving the counter in the right direction\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-for-direction"
   },
   "Correctness/useYield": {
-    "description": "Require generator functions to contain yield.",
+    "description": "Require generator functions to contain yield\\.",
     "url": "https://biomejs.dev/linter/rules/use-yield"
   },
   "Nursery/noCommonJs": {
-    "description": "Disallow use of CommonJs module system in favor of ESM style imports.",
+    "description": "Disallow use of CommonJs module system in favor of ESM style imports\\.",
     "url": "https://biomejs.dev/linter/rules/no-common-js"
   },
   "Nursery/noDescendingSpecificity": {
-    "description": "Disallow a lower specificity selector from coming after a higher specificity selector.",
+    "description": "Disallow a lower specificity selector from coming after a higher specificity selector\\.",
     "url": "https://biomejs.dev/linter/rules/no-descending-specificity"
   },
   "Nursery/noDocumentCookie": {
-    "description": "Disallow direct assignments to document.cookie.",
+    "description": "Disallow direct assignments to document\\.cookie\\.",
     "url": "https://biomejs.dev/linter/rules/no-document-cookie"
   },
   "Nursery/noDocumentImportInPage": {
-    "description": "Prevents importing next/document outside of pages/_document.jsx in Next.js projects.",
+    "description": "Prevents importing next/document outside of pages/\\_document\\.jsx in Next\\.js projects\\.",
     "url": "https://biomejs.dev/linter/rules/no-document-import-in-page"
   },
   "Nursery/noDuplicateCustomProperties": {
-    "description": "Disallow duplicate custom properties within declaration blocks.",
+    "description": "Disallow duplicate custom properties within declaration blocks\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-custom-properties"
   },
   "Nursery/noDuplicateElseIf": {
-    "description": "Disallow duplicate conditions in if-else-if chains",
+    "description": "Disallow duplicate conditions in if\\-else\\-if chains",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-else-if"
   },
   "Nursery/noDuplicateProperties": {
-    "description": "Disallow duplicate properties within declaration blocks.",
+    "description": "Disallow duplicate properties within declaration blocks\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-properties"
   },
   "Nursery/noDuplicatedFields": {
-    "description": "No duplicated fields in GraphQL operations.",
+    "description": "No duplicated fields in GraphQL operations\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicated-fields"
   },
   "Nursery/noDynamicNamespaceImportAccess": {
-    "description": "Disallow accessing namespace imports dynamically.",
+    "description": "Disallow accessing namespace imports dynamically\\.",
     "url": "https://biomejs.dev/linter/rules/no-dynamic-namespace-import-access"
   },
   "Nursery/noEnum": {
-    "description": "Disallow TypeScript enum.",
+    "description": "Disallow TypeScript enum\\.",
     "url": "https://biomejs.dev/linter/rules/no-enum"
   },
   "Nursery/noExportedImports": {
-    "description": "Disallow exporting an imported variable.",
+    "description": "Disallow exporting an imported variable\\.",
     "url": "https://biomejs.dev/linter/rules/no-exported-imports"
   },
   "Nursery/noHeadElement": {
-    "description": "Prevent usage of <head> element in a Next.js project.",
+    "description": "Prevent usage of \\<head\\> element in a Next\\.js project\\.",
     "url": "https://biomejs.dev/linter/rules/no-head-element"
   },
   "Nursery/noHeadImportInDocument": {
-    "description": "Prevent using the next/head module in pages/_document.js on Next.js projects.",
+    "description": "Prevent using the next/head module in pages/\\_document\\.js on Next\\.js projects\\.",
     "url": "https://biomejs.dev/linter/rules/no-head-import-in-document"
   },
   "Nursery/noImgElement": {
-    "description": "Prevent usage of <img> element in a Next.js project.",
+    "description": "Prevent usage of \\<img\\> element in a Next\\.js project\\.",
     "url": "https://biomejs.dev/linter/rules/no-img-element"
   },
   "Nursery/noIrregularWhitespace": {
-    "description": "Disallows the use of irregular whitespace characters.",
+    "description": "Disallows the use of irregular whitespace characters\\.",
     "url": "https://biomejs.dev/linter/rules/no-irregular-whitespace"
   },
   "Nursery/noMissingVarFunction": {
-    "description": "Disallow missing var function for css variables.",
+    "description": "Disallow missing var function for css variables\\.",
     "url": "https://biomejs.dev/linter/rules/no-missing-var-function"
   },
   "Nursery/noNestedTernary": {
-    "description": "Disallow nested ternary expressions.",
+    "description": "Disallow nested ternary expressions\\.",
     "url": "https://biomejs.dev/linter/rules/no-nested-ternary"
   },
   "Nursery/noOctalEscape": {
@@ -548,83 +548,83 @@
     "url": "https://biomejs.dev/linter/rules/no-octal-escape"
   },
   "Nursery/noProcessEnv": {
-    "description": "Disallow the use of process.env.",
+    "description": "Disallow the use of process\\.env\\.",
     "url": "https://biomejs.dev/linter/rules/no-process-env"
   },
   "Nursery/noRestrictedImports": {
-    "description": "Disallow specified modules when loaded by import or require.",
+    "description": "Disallow specified modules when loaded by import or require\\.",
     "url": "https://biomejs.dev/linter/rules/no-restricted-imports"
   },
   "Nursery/noRestrictedTypes": {
-    "description": "Disallow user defined types.",
+    "description": "Disallow user defined types\\.",
     "url": "https://biomejs.dev/linter/rules/no-restricted-types"
   },
   "Nursery/noSecrets": {
-    "description": "Disallow usage of sensitive data such as API keys and tokens.",
+    "description": "Disallow usage of sensitive data such as API keys and tokens\\.",
     "url": "https://biomejs.dev/linter/rules/no-secrets"
   },
   "Nursery/noStaticElementInteractions": {
-    "description": "Enforce that static, visible elements (such as <div>) that have click handlers use the valid role attribute.",
+    "description": "Enforce that static, visible elements \\(such as \\<div\\>\\) that have click handlers use the valid role attribute\\.",
     "url": "https://biomejs.dev/linter/rules/no-static-element-interactions"
   },
   "Nursery/noSubstr": {
-    "description": "Enforce the use of String.slice() over String.substr() and String.substring().",
+    "description": "Enforce the use of String\\.slice\\(\\) over String\\.substr\\(\\) and String\\.substring\\(\\)\\.",
     "url": "https://biomejs.dev/linter/rules/no-substr"
   },
   "Nursery/noTemplateCurlyInString": {
-    "description": "Disallow template literal placeholder syntax in regular strings.",
+    "description": "Disallow template literal placeholder syntax in regular strings\\.",
     "url": "https://biomejs.dev/linter/rules/no-template-curly-in-string"
   },
   "Nursery/noUnknownPseudoClass": {
-    "description": "Disallow unknown pseudo-class selectors.",
+    "description": "Disallow unknown pseudo\\-class selectors\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-pseudo-class"
   },
   "Nursery/noUnknownPseudoElement": {
-    "description": "Disallow unknown pseudo-element selectors.",
+    "description": "Disallow unknown pseudo\\-element selectors\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-pseudo-element"
   },
   "Nursery/noUnknownTypeSelector": {
-    "description": "Disallow unknown type selectors.",
+    "description": "Disallow unknown type selectors\\.",
     "url": "https://biomejs.dev/linter/rules/no-unknown-type-selector"
   },
   "Nursery/noUselessEscapeInRegex": {
-    "description": "Disallow unnecessary escape sequence in regular expression literals.",
+    "description": "Disallow unnecessary escape sequence in regular expression literals\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-escape-in-regex"
   },
   "Nursery/noUselessStringRaw": {
-    "description": "Disallow unnecessary String.raw function in template string literals without any escape sequence.",
+    "description": "Disallow unnecessary String\\.raw function in template string literals without any escape sequence\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-string-raw"
   },
   "Nursery/noValueAtRule": {
-    "description": "Disallow use of @value rule in css modules.",
+    "description": "Disallow use of @value rule in css modules\\.",
     "url": "https://biomejs.dev/linter/rules/no-value-at-rule"
   },
   "Nursery/useAdjacentOverloadSignatures": {
-    "description": "Disallow the use of overload signatures that are not next to each other.",
+    "description": "Disallow the use of overload signatures that are not next to each other\\.",
     "url": "https://biomejs.dev/linter/rules/use-adjacent-overload-signatures"
   },
   "Nursery/useAriaPropsSupportedByRole": {
-    "description": "Enforce that ARIA properties are valid for the roles that are supported by the element.",
+    "description": "Enforce that ARIA properties are valid for the roles that are supported by the element\\.",
     "url": "https://biomejs.dev/linter/rules/use-aria-props-supported-by-role"
   },
   "Nursery/useAtIndex": {
-    "description": "Use at() instead of integer index access.",
+    "description": "Use at\\(\\) instead of integer index access\\.",
     "url": "https://biomejs.dev/linter/rules/use-at-index"
   },
   "Nursery/useCollapsedIf": {
-    "description": "Enforce using single if instead of nested if clauses.",
+    "description": "Enforce using single if instead of nested if clauses\\.",
     "url": "https://biomejs.dev/linter/rules/use-collapsed-if"
   },
   "Nursery/useComponentExportOnlyModules": {
-    "description": "Enforce declaring components only within modules that export React Components exclusively.",
+    "description": "Enforce declaring components only within modules that export React Components exclusively\\.",
     "url": "https://biomejs.dev/linter/rules/use-component-export-only-modules"
   },
   "Nursery/useConsistentCurlyBraces": {
-    "description": "This rule enforces consistent use of curly braces inside JSX attributes and JSX children.",
+    "description": "This rule enforces consistent use of curly braces inside JSX attributes and JSX children\\.",
     "url": "https://biomejs.dev/linter/rules/use-consistent-curly-braces"
   },
   "Nursery/useConsistentMemberAccessibility": {
-    "description": "Require consistent accessibility modifiers on class properties and methods.",
+    "description": "Require consistent accessibility modifiers on class properties and methods\\.",
     "url": "https://biomejs.dev/linter/rules/use-consistent-member-accessibility"
   },
   "Nursery/useDeprecatedReason": {
@@ -632,55 +632,55 @@
     "url": "https://biomejs.dev/linter/rules/use-deprecated-reason"
   },
   "Nursery/useExplicitType": {
-    "description": "Require explicit return types on functions and class methods.",
+    "description": "Require explicit return types on functions and class methods\\.",
     "url": "https://biomejs.dev/linter/rules/use-explicit-type"
   },
   "Nursery/useGoogleFontDisplay": {
-    "description": "Enforces the use of a recommended display strategy with Google Fonts.",
+    "description": "Enforces the use of a recommended display strategy with Google Fonts\\.",
     "url": "https://biomejs.dev/linter/rules/use-google-font-display"
   },
   "Nursery/useGuardForIn": {
-    "description": "Require for-in loops to include an if statement.",
+    "description": "Require for\\-in loops to include an if statement\\.",
     "url": "https://biomejs.dev/linter/rules/use-guard-for-in"
   },
   "Nursery/useImportRestrictions": {
-    "description": "Disallows package private imports.",
+    "description": "Disallows package private imports\\.",
     "url": "https://biomejs.dev/linter/rules/use-import-restrictions"
   },
   "Nursery/useSortedClasses": {
-    "description": "Enforce the sorting of CSS utility classes.",
+    "description": "Enforce the sorting of CSS utility classes\\.",
     "url": "https://biomejs.dev/linter/rules/use-sorted-classes"
   },
   "Nursery/useStrictMode": {
-    "description": "Enforce the use of the directive \"use strict\" in script files.",
+    "description": "Enforce the use of the directive \"use strict\" in script files\\.",
     "url": "https://biomejs.dev/linter/rules/use-strict-mode"
   },
   "Nursery/useTrimStartEnd": {
-    "description": "Enforce the use of String.trimStart() and String.trimEnd() over String.trimLeft() and String.trimRight().",
+    "description": "Enforce the use of String\\.trimStart\\(\\) and String\\.trimEnd\\(\\) over String\\.trimLeft\\(\\) and String\\.trimRight\\(\\)\\.",
     "url": "https://biomejs.dev/linter/rules/use-trim-start-end"
   },
   "Nursery/useValidAutocomplete": {
-    "description": "Use valid values for the autocomplete attribute on input elements.",
+    "description": "Use valid values for the autocomplete attribute on input elements\\.",
     "url": "https://biomejs.dev/linter/rules/use-valid-autocomplete"
   },
   "Performance/noAccumulatingSpread": {
-    "description": "Disallow the use of spread (...) syntax on accumulators.",
+    "description": "Disallow the use of spread \\(\\.\\.\\.\\) syntax on accumulators\\.",
     "url": "https://biomejs.dev/linter/rules/no-accumulating-spread"
   },
   "Performance/noBarrelFile": {
-    "description": "Disallow the use of barrel file.",
+    "description": "Disallow the use of barrel file\\.",
     "url": "https://biomejs.dev/linter/rules/no-barrel-file"
   },
   "Performance/noDelete": {
-    "description": "Disallow the use of the delete operator.",
+    "description": "Disallow the use of the delete operator\\.",
     "url": "https://biomejs.dev/linter/rules/no-delete"
   },
   "Performance/noReExportAll": {
-    "description": "Avoid re-export all.",
+    "description": "Avoid re\\-export all\\.",
     "url": "https://biomejs.dev/linter/rules/no-re-export-all"
   },
   "Performance/useTopLevelRegex": {
-    "description": "Require regex literals to be declared at the top level.",
+    "description": "Require regex literals to be declared at the top level\\.",
     "url": "https://biomejs.dev/linter/rules/use-top-level-regex"
   },
   "Security/noDangerouslySetInnerHtml": {
@@ -688,27 +688,27 @@
     "url": "https://biomejs.dev/linter/rules/no-dangerously-set-inner-html/"
   },
   "Security/noDangerouslySetInnerHtmlWithChildren": {
-    "description": "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.",
+    "description": "Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop\\.",
     "url": "https://biomejs.dev/linter/rules/no-dangerously-set-inner-html-with-children"
   },
   "Security/noGlobalEval": {
-    "description": "Disallow the use of global eval().",
+    "description": "Disallow the use of global eval\\(\\)\\.",
     "url": "https://biomejs.dev/linter/rules/no-global-eval"
   },
   "Style/noArguments": {
-    "description": "Disallow the use of arguments.",
+    "description": "Disallow the use of arguments\\.",
     "url": "https://biomejs.dev/linter/rules/no-arguments"
   },
   "Style/noCommaOperator": {
-    "description": "Disallow comma operator.",
+    "description": "Disallow comma operator\\.",
     "url": "https://biomejs.dev/linter/rules/no-comma-operator"
   },
   "Style/noDefaultExport": {
-    "description": "Disallow default exports.",
+    "description": "Disallow default exports\\.",
     "url": "https://biomejs.dev/linter/rules/no-default-export"
   },
   "Style/noDoneCallback": {
-    "description": "Disallow using a callback in asynchronous tests and hooks.",
+    "description": "Disallow using a callback in asynchronous tests and hooks\\.",
     "url": "https://biomejs.dev/linter/rules/no-done-callback"
   },
   "Style/noImplicitBoolean": {
@@ -716,47 +716,47 @@
     "url": "https://biomejs.dev/linter/rules/no-implicit-boolean"
   },
   "Style/noInferrableTypes": {
-    "description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.",
+    "description": "Disallow type annotations for variables, parameters, and class properties initialized with a literal expression\\.",
     "url": "https://biomejs.dev/linter/rules/no-inferrable-types"
   },
   "Style/noNamespace": {
-    "description": "Disallow the use of TypeScript’s namespaces.",
+    "description": "Disallow the use of TypeScript’s namespaces\\.",
     "url": "https://biomejs.dev/linter/rules/no-namespace"
   },
   "Style/noNamespaceImport": {
-    "description": "Disallow the use of namespace imports.",
+    "description": "Disallow the use of namespace imports\\.",
     "url": "https://biomejs.dev/linter/rules/no-namespace-import"
   },
   "Style/noNegationElse": {
-    "description": "Disallow negation in the condition of an if statement if it has an else clause.",
+    "description": "Disallow negation in the condition of an if statement if it has an else clause\\.",
     "url": "https://biomejs.dev/linter/rules/no-negation-else"
   },
   "Style/noNonNullAssertion": {
-    "description": "Disallow non-null assertions using the ! postfix operator.",
+    "description": "Disallow non\\-null assertions using the \\! postfix operator\\.",
     "url": "https://biomejs.dev/linter/rules/no-non-null-assertion"
   },
   "Style/noParameterAssign": {
-    "description": "Disallow reassigning function parameters.",
+    "description": "Disallow reassigning function parameters\\.",
     "url": "https://biomejs.dev/linter/rules/no-parameter-assign"
   },
   "Style/noParameterProperties": {
-    "description": "Disallow the use of parameter properties in class constructors.",
+    "description": "Disallow the use of parameter properties in class constructors\\.",
     "url": "https://biomejs.dev/linter/rules/no-parameter-properties"
   },
   "Style/noRestrictedGlobals": {
-    "description": "This rule allows you to specify global variable names that you don’t want to use in your application.",
+    "description": "This rule allows you to specify global variable names that you don’t want to use in your application\\.",
     "url": "https://biomejs.dev/linter/rules/no-restricted-globals"
   },
   "Style/noShoutyConstants": {
-    "description": "Disallow the use of constants which its value is the upper-case version of its name.",
+    "description": "Disallow the use of constants which its value is the upper\\-case version of its name\\.",
     "url": "https://biomejs.dev/linter/rules/no-shouty-constants"
   },
   "Style/noUnusedTemplateLiteral": {
-    "description": "Disallow template literals if interpolation and special-character handling are not needed",
+    "description": "Disallow template literals if interpolation and special\\-character handling are not needed",
     "url": "https://biomejs.dev/linter/rules/no-unused-template-literal"
   },
   "Style/noUselessElse": {
-    "description": "Disallow else block when the if block breaks early.",
+    "description": "Disallow else block when the if block breaks early\\.",
     "url": "https://biomejs.dev/linter/rules/no-useless-else"
   },
   "Style/noVar": {
@@ -764,95 +764,95 @@
     "url": "https://biomejs.dev/linter/rules/no-var"
   },
   "Style/noYodaExpression": {
-    "description": "Disallow the use of yoda expressions.",
+    "description": "Disallow the use of yoda expressions\\.",
     "url": "https://biomejs.dev/linter/rules/no-yoda-expression"
   },
   "Style/useAsConstAssertion": {
-    "description": "Enforce the use of as const over literal type and type annotation.",
+    "description": "Enforce the use of as const over literal type and type annotation\\.",
     "url": "https://biomejs.dev/linter/rules/use-as-const-assertion"
   },
   "Style/useBlockStatements": {
-    "description": "Requires following curly brace conventions.",
+    "description": "Requires following curly brace conventions\\.",
     "url": "https://biomejs.dev/linter/rules/use-block-statements"
   },
   "Style/useCollapsedElseIf": {
-    "description": "Enforce using else if instead of nested if in else clauses.",
+    "description": "Enforce using else if instead of nested if in else clauses\\.",
     "url": "https://biomejs.dev/linter/rules/use-collapsed-else-if"
   },
   "Style/useConsistentArrayType": {
-    "description": "Require consistently using either T[] or Array<T>",
+    "description": "Require consistently using either T\\[\\] or Array\\<T\\>",
     "url": "https://biomejs.dev/linter/rules/use-consistent-array-type"
   },
   "Style/useConsistentBuiltinInstantiation": {
-    "description": "Enforce the use of new for all builtins, except String, Number and Boolean.",
+    "description": "Enforce the use of new for all builtins, except String, Number and Boolean\\.",
     "url": "https://biomejs.dev/linter/rules/use-consistent-builtin-instantiation"
   },
   "Style/useConst": {
-    "description": "Require const declarations for variables that are only assigned once.",
+    "description": "Require const declarations for variables that are only assigned once\\.",
     "url": "https://biomejs.dev/linter/rules/use-const"
   },
   "Style/useDefaultParameterLast": {
-    "description": "Enforce default function parameters and optional function parameters to be last.",
+    "description": "Enforce default function parameters and optional function parameters to be last\\.",
     "url": "https://biomejs.dev/linter/rules/use-default-parameter-last"
   },
   "Style/useDefaultSwitchClause": {
-    "description": "Require the default clause in switch statements.",
+    "description": "Require the default clause in switch statements\\.",
     "url": "https://biomejs.dev/linter/rules/use-default-switch-clause"
   },
   "Style/useEnumInitializers": {
-    "description": "Require that each enum member value be explicitly initialized.",
+    "description": "Require that each enum member value be explicitly initialized\\.",
     "url": "https://biomejs.dev/linter/rules/use-enum-initializers"
   },
   "Style/useExplicitLengthCheck": {
-    "description": "Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value.",
+    "description": "Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value\\.",
     "url": "https://biomejs.dev/linter/rules/use-explicit-length-check"
   },
   "Style/useExponentiationOperator": {
-    "description": "Disallow the use of Math.pow in favor of the ** operator.",
+    "description": "Disallow the use of Math\\.pow in favor of the \\*\\* operator\\.",
     "url": "https://biomejs.dev/linter/rules/use-exponentiation-operator"
   },
   "Style/useExportType": {
-    "description": "Promotes the use of export type for types.",
+    "description": "Promotes the use of export type for types\\.",
     "url": "https://biomejs.dev/linter/rules/use-export-type"
   },
   "Style/useFilenamingConvention": {
-    "description": "Enforce naming conventions for JavaScript and TypeScript filenames.",
+    "description": "Enforce naming conventions for JavaScript and TypeScript filenames\\.",
     "url": "https://biomejs.dev/linter/rules/use-filenaming-convention"
   },
   "Style/useForOf": {
-    "description": "This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.",
+    "description": "This rule recommends a for\\-of loop when in a for loop, the index used to extract an item from the iterated array\\.",
     "url": "https://biomejs.dev/linter/rules/use-for-of"
   },
   "Style/useFragmentSyntax": {
-    "description": "This rule enforces the use of <>...</> over <Fragment>...</Fragment>.",
+    "description": "This rule enforces the use of \\<\\>\\.\\.\\.\\</\\> over \\<Fragment\\>\\.\\.\\.\\</Fragment\\>\\.",
     "url": "https://biomejs.dev/linter/rules/use-fragment-syntax"
   },
   "Style/useImportType": {
-    "description": "Promotes the use of import type for types.",
+    "description": "Promotes the use of import type for types\\.",
     "url": "https://biomejs.dev/linter/rules/use-import-type"
   },
   "Style/useLiteralEnumMembers": {
-    "description": "Require all enum members to be literal values.",
+    "description": "Require all enum members to be literal values\\.",
     "url": "https://biomejs.dev/linter/rules/use-literal-enum-members"
   },
   "Style/useNamingConvention": {
-    "description": "Enforce naming conventions for everything across a codebase.",
+    "description": "Enforce naming conventions for everything across a codebase\\.",
     "url": "https://biomejs.dev/linter/rules/use-naming-convention"
   },
   "Style/useNodeAssertStrict": {
-    "description": "Promotes the usage of node:assert/strict over node:assert.",
+    "description": "Promotes the usage of node:assert/strict over node:assert\\.",
     "url": "https://biomejs.dev/linter/rules/use-node-assert-strict"
   },
   "Style/useNodejsImportProtocol": {
-    "description": "Enforces using the node: protocol for Node.js builtin modules.",
+    "description": "Enforces using the node: protocol for Node\\.js builtin modules\\.",
     "url": "https://biomejs.dev/linter/rules/use-nodejs-import-protocol"
   },
   "Style/useNumberNamespace": {
-    "description": "Use the Number properties instead of global ones.",
+    "description": "Use the Number properties instead of global ones\\.",
     "url": "https://biomejs.dev/linter/rules/use-number-namespace"
   },
   "Style/useNumericLiterals": {
-    "description": "Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals",
+    "description": "Disallow parseInt\\(\\) and Number\\.parseInt\\(\\) in favor of binary, octal, and hexadecimal literals",
     "url": "https://biomejs.dev/linter/rules/use-numeric-literals"
   },
   "Style/useSelfClosingElements": {
@@ -860,19 +860,19 @@
     "url": "https://biomejs.dev/linter/rules/use-self-closing-elements"
   },
   "Style/useShorthandArrayType": {
-    "description": "When expressing array types, this rule promotes the usage of T[] shorthand instead of Array<T>.",
+    "description": "When expressing array types, this rule promotes the usage of T\\[\\] shorthand instead of Array\\<T\\>\\.",
     "url": "https://biomejs.dev/linter/rules/use-shorthand-array-type"
   },
   "Style/useShorthandAssign": {
-    "description": "Require assignment operator shorthand where possible.",
+    "description": "Require assignment operator shorthand where possible\\.",
     "url": "https://biomejs.dev/linter/rules/use-shorthand-assign"
   },
   "Style/useShorthandFunctionType": {
-    "description": "Enforce using function types instead of object type with call signatures.",
+    "description": "Enforce using function types instead of object type with call signatures\\.",
     "url": "https://biomejs.dev/linter/rules/use-shorthand-function-type"
   },
   "Style/useSingleCaseStatement": {
-    "description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.",
+    "description": "Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block\\.",
     "url": "https://biomejs.dev/linter/rules/use-single-case-statement"
   },
   "Style/useSingleVarDeclarator": {
@@ -880,43 +880,43 @@
     "url": "https://biomejs.dev/linter/rules/use-single-var-declarator"
   },
   "Style/useTemplate": {
-    "description": "Prefer template literals over string concatenation.",
+    "description": "Prefer template literals over string concatenation\\.",
     "url": "https://biomejs.dev/linter/rules/use-template"
   },
   "Style/useThrowNewError": {
-    "description": "Require new when throwing an error.",
+    "description": "Require new when throwing an error\\.",
     "url": "https://biomejs.dev/linter/rules/use-throw-new-error"
   },
   "Style/useThrowOnlyError": {
-    "description": "Disallow throwing non-Error values.",
+    "description": "Disallow throwing non\\-Error values\\.",
     "url": "https://biomejs.dev/linter/rules/use-throw-only-error"
   },
   "Style/useWhile": {
-    "description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.",
+    "description": "Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed\\.",
     "url": "https://biomejs.dev/linter/rules/use-while"
   },
   "Suspicious/noApproximativeNumericConstant": {
-    "description": "Use standard constants instead of approximated literals.",
+    "description": "Use standard constants instead of approximated literals\\.",
     "url": "https://biomejs.dev/linter/rules/no-approximative-numeric-constant"
   },
   "Suspicious/noArrayIndexKey": {
-    "description": "Discourage the usage of Array index in keys.",
+    "description": "Discourage the usage of Array index in keys\\.",
     "url": "https://biomejs.dev/linter/rules/no-array-index-key"
   },
   "Suspicious/noAssignInExpressions": {
-    "description": "Disallow assignments in expressions.",
+    "description": "Disallow assignments in expressions\\.",
     "url": "https://biomejs.dev/linter/rules/no-assign-in-expressions"
   },
   "Suspicious/noAsyncPromiseExecutor": {
-    "description": "Disallows using an async function as a Promise executor.",
+    "description": "Disallows using an async function as a Promise executor\\.",
     "url": "https://biomejs.dev/linter/rules/no-async-promise-executor"
   },
   "Suspicious/noCatchAssign": {
-    "description": "Disallow reassigning exceptions in catch clauses.",
+    "description": "Disallow reassigning exceptions in catch clauses\\.",
     "url": "https://biomejs.dev/linter/rules/no-catch-assign"
   },
   "Suspicious/noClassAssign": {
-    "description": "Disallow reassigning class members.",
+    "description": "Disallow reassigning class members\\.",
     "url": "https://biomejs.dev/linter/rules/no-class-assign"
   },
   "Suspicious/noCommentText": {
@@ -924,23 +924,23 @@
     "url": "https://biomejs.dev/linter/rules/no-comment-text"
   },
   "Suspicious/noCompareNegZero": {
-    "description": "Disallow comparing against -0",
+    "description": "Disallow comparing against \\-0",
     "url": "https://biomejs.dev/linter/rules/no-compare-neg-zero"
   },
   "Suspicious/noConfusingLabels": {
-    "description": "Disallow labeled statements that are not loops.",
+    "description": "Disallow labeled statements that are not loops\\.",
     "url": "https://biomejs.dev/linter/rules/no-confusing-labels"
   },
   "Suspicious/noConfusingVoidType": {
-    "description": "Disallow void type outside of generic or return types.",
+    "description": "Disallow void type outside of generic or return types\\.",
     "url": "https://biomejs.dev/linter/rules/no-confusing-void-type"
   },
   "Suspicious/noConsole": {
-    "description": "Disallow the use of console.",
+    "description": "Disallow the use of console\\.",
     "url": "https://biomejs.dev/linter/rules/no-console"
   },
   "Suspicious/noConsoleLog": {
-    "description": "Disallow the use of console.log",
+    "description": "Disallow the use of console\\.log",
     "url": "https://biomejs.dev/linter/rules/no-console-log"
   },
   "Suspicious/noConstEnum": {
@@ -948,7 +948,7 @@
     "url": "https://biomejs.dev/linter/rules/no-const-enum"
   },
   "Suspicious/noControlCharactersInRegex": {
-    "description": "Prevents from having control characters and some escape sequences that match control characters in regular expressions.",
+    "description": "Prevents from having control characters and some escape sequences that match control characters in regular expressions\\.",
     "url": "https://biomejs.dev/linter/rules/no-control-characters-in-regex"
   },
   "Suspicious/noDebugger": {
@@ -956,99 +956,99 @@
     "url": "https://biomejs.dev/linter/rules/no-debugger"
   },
   "Suspicious/noDoubleEquals": {
-    "description": "Require the use of === and !==.",
+    "description": "Require the use of === and \\!==\\.",
     "url": "https://biomejs.dev/linter/rules/no-double-equals"
   },
   "Suspicious/noDuplicateAtImportRules": {
-    "description": "Disallow duplicate @import rules.",
+    "description": "Disallow duplicate @import rules\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-at-import-rules"
   },
   "Suspicious/noDuplicateCase": {
-    "description": "Disallow duplicate case labels.",
+    "description": "Disallow duplicate case labels\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-case"
   },
   "Suspicious/noDuplicateClassMembers": {
-    "description": "Disallow duplicate class members.",
+    "description": "Disallow duplicate class members\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-class-members"
   },
   "Suspicious/noDuplicateFontNames": {
-    "description": "Disallow duplicate names within font families.",
+    "description": "Disallow duplicate names within font families\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-font-names"
   },
   "Suspicious/noDuplicateJsxProps": {
-    "description": "Prevents JSX properties to be assigned multiple times.",
+    "description": "Prevents JSX properties to be assigned multiple times\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-jsx-props"
   },
   "Suspicious/noDuplicateObjectKeys": {
-    "description": "Disallow two keys with the same name inside objects.",
+    "description": "Disallow two keys with the same name inside objects\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-object-keys"
   },
   "Suspicious/noDuplicateParameters": {
-    "description": "Disallow duplicate function parameter name.",
+    "description": "Disallow duplicate function parameter name\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-parameters"
   },
   "Suspicious/noDuplicateSelectorsKeyframeBlock": {
-    "description": "Disallow duplicate selectors within keyframe blocks.",
+    "description": "Disallow duplicate selectors within keyframe blocks\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-selectors-keyframe-block"
   },
   "Suspicious/noDuplicateTestHooks": {
-    "description": "A describe block should not contain duplicate hooks.",
+    "description": "A describe block should not contain duplicate hooks\\.",
     "url": "https://biomejs.dev/linter/rules/no-duplicate-test-hooks"
   },
   "Suspicious/noEmptyBlock": {
-    "description": "Disallow CSS empty blocks.",
+    "description": "Disallow CSS empty blocks\\.",
     "url": "https://biomejs.dev/linter/rules/no-empty-block"
   },
   "Suspicious/noEmptyBlockStatements": {
-    "description": "Disallow empty block statements and static blocks.",
+    "description": "Disallow empty block statements and static blocks\\.",
     "url": "https://biomejs.dev/linter/rules/no-empty-block-statements"
   },
   "Suspicious/noEmptyInterface": {
-    "description": "Disallow the declaration of empty interfaces.",
+    "description": "Disallow the declaration of empty interfaces\\.",
     "url": "https://biomejs.dev/linter/rules/no-empty-interface"
   },
   "Suspicious/noEvolvingTypes": {
-    "description": "Disallow variables from evolving into any type through reassignments.",
+    "description": "Disallow variables from evolving into any type through reassignments\\.",
     "url": "https://biomejs.dev/linter/rules/no-evolving-types"
   },
   "Suspicious/noExplicitAny": {
-    "description": "Disallow the any type usage.",
+    "description": "Disallow the any type usage\\.",
     "url": "https://biomejs.dev/linter/rules/no-explicit-any"
   },
   "Suspicious/noExportsInTest": {
-    "description": "Disallow using export or module.exports in files containing tests",
+    "description": "Disallow using export or module\\.exports in files containing tests",
     "url": "https://biomejs.dev/linter/rules/no-exports-in-test"
   },
   "Suspicious/noExtraNonNullAssertion": {
-    "description": "Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.",
+    "description": "Prevents the wrong usage of the non\\-null assertion operator \\(\\!\\) in TypeScript files\\.",
     "url": "https://biomejs.dev/linter/rules/no-extra-non-null-assertion"
   },
   "Suspicious/noFallthroughSwitchClause": {
-    "description": "Disallow fallthrough of switch clauses.",
+    "description": "Disallow fallthrough of switch clauses\\.",
     "url": "https://biomejs.dev/linter/rules/no-fallthrough-switch-clause"
   },
   "Suspicious/noFocusedTests": {
-    "description": "Disallow focused tests.",
+    "description": "Disallow focused tests\\.",
     "url": "https://biomejs.dev/linter/rules/no-focused-tests"
   },
   "Suspicious/noFunctionAssign": {
-    "description": "Disallow reassigning function declarations.",
+    "description": "Disallow reassigning function declarations\\.",
     "url": "https://biomejs.dev/linter/rules/no-function-assign"
   },
   "Suspicious/noGlobalAssign": {
-    "description": "Disallow assignments to native objects and read-only global variables.",
+    "description": "Disallow assignments to native objects and read\\-only global variables\\.",
     "url": "https://biomejs.dev/linter/rules/no-global-assign"
   },
   "Suspicious/noGlobalIsFinite": {
-    "description": "Use Number.isFinite instead of global isFinite.",
+    "description": "Use Number\\.isFinite instead of global isFinite\\.",
     "url": "https://biomejs.dev/linter/rules/no-global-is-finite"
   },
   "Suspicious/noGlobalIsNan": {
-    "description": "Use Number.isNaN instead of global isNaN.",
+    "description": "Use Number\\.isNaN instead of global isNaN\\.",
     "url": "https://biomejs.dev/linter/rules/no-global-is-nan"
   },
   "Suspicious/noImplicitAnyLet": {
-    "description": "Disallow use of implicit any type on variable declarations.",
+    "description": "Disallow use of implicit any type on variable declarations\\.",
     "url": "https://biomejs.dev/linter/rules/no-implicit-any-let"
   },
   "Suspicious/noImportAssign": {
@@ -1056,7 +1056,7 @@
     "url": "https://biomejs.dev/linter/rules/no-import-assign"
   },
   "Suspicious/noImportantInKeyframe": {
-    "description": "Disallow invalid !important within keyframe declarations",
+    "description": "Disallow invalid \\!important within keyframe declarations",
     "url": "https://biomejs.dev/linter/rules/no-important-in-keyframe"
   },
   "Suspicious/noLabelVar": {
@@ -1064,51 +1064,51 @@
     "url": "https://biomejs.dev/linter/rules/no-label-var"
   },
   "Suspicious/noMisleadingCharacterClass": {
-    "description": "Disallow characters made with multiple code points in character class syntax.",
+    "description": "Disallow characters made with multiple code points in character class syntax\\.",
     "url": "https://biomejs.dev/linter/rules/no-misleading-character-class"
   },
   "Suspicious/noMisleadingInstantiator": {
-    "description": "Enforce proper usage of new and constructor.",
+    "description": "Enforce proper usage of new and constructor\\.",
     "url": "https://biomejs.dev/linter/rules/no-misleading-instantiator"
   },
   "Suspicious/noMisplacedAssertion": {
-    "description": "Checks that the assertion function, for example expect, is placed inside an it() function call.",
+    "description": "Checks that the assertion function, for example expect, is placed inside an it\\(\\) function call\\.",
     "url": "https://biomejs.dev/linter/rules/no-misplaced-assertion"
   },
   "Suspicious/noMisrefactoredShorthandAssign": {
-    "description": "Disallow shorthand assign when variable appears on both sides.",
+    "description": "Disallow shorthand assign when variable appears on both sides\\.",
     "url": "https://biomejs.dev/linter/rules/no-misrefactored-shorthand-assign"
   },
   "Suspicious/noPrototypeBuiltins": {
-    "description": "Disallow direct use of Object.prototype builtins.",
+    "description": "Disallow direct use of Object\\.prototype builtins\\.",
     "url": "https://biomejs.dev/linter/rules/no-prototype-builtins"
   },
   "Suspicious/noReactSpecificProps": {
-    "description": "Prevents React-specific JSX properties from being used.",
+    "description": "Prevents React\\-specific JSX properties from being used\\.",
     "url": "https://biomejs.dev/linter/rules/no-react-specific-props"
   },
   "Suspicious/noRedeclare": {
-    "description": "Disallow variable, function, class, and type redeclarations in the same scope.",
+    "description": "Disallow variable, function, class, and type redeclarations in the same scope\\.",
     "url": "https://biomejs.dev/linter/rules/no-redeclare"
   },
   "Suspicious/noRedundantUseStrict": {
-    "description": "Prevents from having redundant \"use strict\".",
+    "description": "Prevents from having redundant \"use strict\"\\.",
     "url": "https://biomejs.dev/linter/rules/no-redundant-use-strict"
   },
   "Suspicious/noSelfCompare": {
-    "description": "Disallow comparisons where both sides are exactly the same.",
+    "description": "Disallow comparisons where both sides are exactly the same\\.",
     "url": "https://biomejs.dev/linter/rules/no-self-compare"
   },
   "Suspicious/noShadowRestrictedNames": {
-    "description": "Disallow identifiers from shadowing restricted names.",
+    "description": "Disallow identifiers from shadowing restricted names\\.",
     "url": "https://biomejs.dev/linter/rules/no-shadow-restricted-names"
   },
   "Suspicious/noShorthandPropertyOverrides": {
-    "description": "Disallow shorthand properties that override related longhand properties.",
+    "description": "Disallow shorthand properties that override related longhand properties\\.",
     "url": "https://biomejs.dev/linter/rules/no-shorthand-property-overrides"
   },
   "Suspicious/noSkippedTests": {
-    "description": "Disallow disabled tests.",
+    "description": "Disallow disabled tests\\.",
     "url": "https://biomejs.dev/linter/rules/no-skipped-tests"
   },
   "Suspicious/noSparseArray": {
@@ -1116,23 +1116,23 @@
     "url": "https://biomejs.dev/linter/rules/no-sparse-array"
   },
   "Suspicious/noSuspiciousSemicolonInJsx": {
-    "description": "It detects possible “wrong” semicolons inside JSX elements.",
+    "description": "It detects possible “wrong” semicolons inside JSX elements\\.",
     "url": "https://biomejs.dev/linter/rules/no-suspicious-semicolon-in-jsx"
   },
   "Suspicious/noThenProperty": {
-    "description": "Disallow then property.",
+    "description": "Disallow then property\\.",
     "url": "https://biomejs.dev/linter/rules/no-then-property"
   },
   "Suspicious/noUnsafeDeclarationMerging": {
-    "description": "Disallow unsafe declaration merging between interfaces and classes.",
+    "description": "Disallow unsafe declaration merging between interfaces and classes\\.",
     "url": "https://biomejs.dev/linter/rules/no-unsafe-declaration-merging"
   },
   "Suspicious/noUnsafeNegation": {
-    "description": "Disallow using unsafe negation.",
+    "description": "Disallow using unsafe negation\\.",
     "url": "https://biomejs.dev/linter/rules/no-unsafe-negation"
   },
   "Suspicious/useAwait": {
-    "description": "Ensure async functions utilize await.",
+    "description": "Ensure async functions utilize await\\.",
     "url": "https://biomejs.dev/linter/rules/use-await"
   },
   "Suspicious/useDefaultSwitchClauseLast": {
@@ -1140,23 +1140,23 @@
     "url": "https://biomejs.dev/linter/rules/use-default-switch-clause-last"
   },
   "Suspicious/useErrorMessage": {
-    "description": "Enforce passing a message value when creating a built-in error.",
+    "description": "Enforce passing a message value when creating a built\\-in error\\.",
     "url": "https://biomejs.dev/linter/rules/use-error-message"
   },
   "Suspicious/useGetterReturn": {
-    "description": "Enforce get methods to always return a value.",
+    "description": "Enforce get methods to always return a value\\.",
     "url": "https://biomejs.dev/linter/rules/use-getter-return"
   },
   "Suspicious/useIsArray": {
-    "description": "Use Array.isArray() instead of instanceof Array.",
+    "description": "Use Array\\.isArray\\(\\) instead of instanceof Array\\.",
     "url": "https://biomejs.dev/linter/rules/use-is-array"
   },
   "Suspicious/useNamespaceKeyword": {
-    "description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces.",
+    "description": "Require using the namespace keyword over the module keyword to declare TypeScript namespaces\\.",
     "url": "https://biomejs.dev/linter/rules/use-namespace-keyword"
   },
   "Suspicious/useNumberToFixedDigitsArgument": {
-    "description": "Enforce using the digits argument with Number#toFixed().",
+    "description": "Enforce using the digits argument with Number\\#toFixed\\(\\)\\.",
     "url": "https://biomejs.dev/linter/rules/use-number-to-fixed-digits-argument"
   },
   "Suspicious/useValidTypeof": {

--- a/src/markdown/biome-to-markdown.test.ts
+++ b/src/markdown/biome-to-markdown.test.ts
@@ -50,8 +50,8 @@ describe('biome-to-markdown', () => {
         "### style
 
         - [\`noImplicitBoolean\`](https://biomejs.dev/linter/rules/no-implicit-boolean): Disallow implicit true values on JSX boolean attributes
-        - [\`useBlockStatements\`](https://biomejs.dev/linter/rules/use-block-statements): Requires following curly brace conventions.
-        - [\`useTemplate\`](https://biomejs.dev/linter/rules/use-template): Prefer template literals over string concatenation.
+        - [\`useBlockStatements\`](https://biomejs.dev/linter/rules/use-block-statements): Requires following curly brace conventions\\.
+        - [\`useTemplate\`](https://biomejs.dev/linter/rules/use-template): Prefer template literals over string concatenation\\.
         "
       `)
     })
@@ -90,18 +90,18 @@ describe('biome-to-markdown', () => {
 
         ### accessibility
 
-        - [\`noAutofocus\`](https://biomejs.dev/linter/rules/no-autofocus): Enforce that autoFocus prop is not used on elements.
-        - [\`useAltText\`](https://biomejs.dev/linter/rules/use-alt-text): Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
+        - [\`noAutofocus\`](https://biomejs.dev/linter/rules/no-autofocus): Enforce that autoFocus prop is not used on elements\\.
+        - [\`useAltText\`](https://biomejs.dev/linter/rules/use-alt-text): Enforce that all elements that require alternative text have meaningful information to relay back to the end user\\.
 
         ### style
 
         - [\`noImplicitBoolean\`](https://biomejs.dev/linter/rules/no-implicit-boolean): Disallow implicit true values on JSX boolean attributes
-        - [\`useTemplate\`](https://biomejs.dev/linter/rules/use-template): Prefer template literals over string concatenation.
+        - [\`useTemplate\`](https://biomejs.dev/linter/rules/use-template): Prefer template literals over string concatenation\\.
 
         ### suspicious
 
-        - [\`noCatchAssign\`](https://biomejs.dev/linter/rules/no-catch-assign): Disallow reassigning exceptions in catch clauses.
-        - [\`noExplicitAny\`](https://biomejs.dev/linter/rules/no-explicit-any): Disallow the any type usage.
+        - [\`noCatchAssign\`](https://biomejs.dev/linter/rules/no-catch-assign): Disallow reassigning exceptions in catch clauses\\.
+        - [\`noExplicitAny\`](https://biomejs.dev/linter/rules/no-explicit-any): Disallow the any type usage\\.
         "
       `)
     })

--- a/src/parsers/biome-parser.test.ts
+++ b/src/parsers/biome-parser.test.ts
@@ -138,7 +138,7 @@ describe('parseBiomeRules', () => {
       const firstRule = firstCategory.rules[0]
       expect(firstRule).toBeDefined()
       if (firstRule) {
-        expect(firstRule.description).toBe('Disallow reassigning exceptions in catch clauses.')
+        expect(firstRule.description).toBe('Disallow reassigning exceptions in catch clauses\\.')
         expect(firstRule.url).toBe('https://biomejs.dev/linter/rules/no-catch-assign')
       }
     }


### PR DESCRIPTION
## 概要
- マークダウンで特殊な意味を持つ文字をエスケープする関数を追加し、レンダリング崩れを解消
- マークダウン内にHTMLタグなどの特殊文字があると正しく表示されない問題を修正
- 特に`<th>`タグを含む記述がマークダウンのテーブル構造を崩す問題に対応

## 修正内容
- `escapeMarkdownSpecialChars`関数を追加して、特殊文字を適切にエスケープ
- スクリプト実行時にbiome-rules.jsonの説明文を全てエスケープ処理
- ESLintの警告に対応（不要なエスケープ文字の削除）

## テスト方法
- 生成されたマークダウンファイルでHTMLタグや特殊文字が正しく表示されることを確認
- ESLintのエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)